### PR TITLE
Fix #22: Support for Publisher<DataBuffer>

### DIFF
--- a/rest-client-base/src/main/java/com/wultra/core/rest/client/base/DefaultRestClient.java
+++ b/rest-client-base/src/main/java/com/wultra/core/rest/client/base/DefaultRestClient.java
@@ -25,7 +25,9 @@ import io.netty.channel.ChannelOption;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import org.reactivestreams.Publisher;
 import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -534,8 +536,12 @@ public class DefaultRestClient implements RestClient {
      * @param request Request data.
      * @return Mono with ClientResponse.
      */
+    @SuppressWarnings("unchecked")
     private Mono<ClientResponse> buildResponseMono(WebClient.RequestBodySpec requestSpec, Object request) {
         if (request != null) {
+            if (request instanceof Publisher) {
+                return requestSpec.body(BodyInserters.fromDataBuffers((Publisher<DataBuffer>) request)).exchange();
+            }
             return requestSpec.body(BodyInserters.fromValue(request)).exchange();
         } else {
             return requestSpec.exchange();


### PR DESCRIPTION
I added support for `Publisher<DataBuffer>`. This is a quick solution, we will add proper support with the fluent API to switch between `Object` and `Flux<DataBuffer>` options. I didn't want to introduce new methods for this purpose in this release. We'll definitely need to improve the API for these different use cases in the next release.