### PR TITLE
Fix #27: Add javax.validation annotations to model

### DIFF
--- a/rest-model-base/pom.xml
+++ b/rest-model-base/pom.xml
@@ -18,6 +18,12 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>jakarta.validation</groupId>
+			<artifactId>jakarta.validation-api</artifactId>
+			<version>2.0.2</version>
+			<scope>compile</scope>
+		</dependency>
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>4.13.1</version>

--- a/rest-model-base/src/main/java/io/getlime/core/rest/model/base/entity/Error.java
+++ b/rest-model-base/src/main/java/io/getlime/core/rest/model/base/entity/Error.java
@@ -15,6 +15,8 @@
  */
 package io.getlime.core.rest.model.base.entity;
 
+import javax.validation.constraints.NotBlank;
+
 /**
  * Transport object for RESTful API representing an error instance.
  *
@@ -42,6 +44,7 @@ public class Error {
         public static final String UNKNOWN_ERROR = "UNKNOWN_ERROR";
     }
 
+    @NotBlank
     private String code;
     private String message;
 

--- a/rest-model-base/src/main/java/io/getlime/core/rest/model/base/request/ObjectRequest.java
+++ b/rest-model-base/src/main/java/io/getlime/core/rest/model/base/request/ObjectRequest.java
@@ -15,6 +15,8 @@
  */
 package io.getlime.core.rest.model.base.request;
 
+import javax.validation.Valid;
+
 /**
  * Simple class representing a request with an object.
  *
@@ -24,6 +26,7 @@ package io.getlime.core.rest.model.base.request;
  */
 public class ObjectRequest<T> {
 
+    @Valid
     private T requestObject;
 
     /**

--- a/rest-model-base/src/main/java/io/getlime/core/rest/model/base/request/ObjectRequest.java
+++ b/rest-model-base/src/main/java/io/getlime/core/rest/model/base/request/ObjectRequest.java
@@ -16,6 +16,7 @@
 package io.getlime.core.rest.model.base.request;
 
 import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 
 /**
  * Simple class representing a request with an object.
@@ -27,6 +28,7 @@ import javax.validation.Valid;
 public class ObjectRequest<T> {
 
     @Valid
+    @NotNull
     private T requestObject;
 
     /**

--- a/rest-model-base/src/main/java/io/getlime/core/rest/model/base/response/ErrorResponse.java
+++ b/rest-model-base/src/main/java/io/getlime/core/rest/model/base/response/ErrorResponse.java
@@ -17,6 +17,9 @@ package io.getlime.core.rest.model.base.response;
 
 import io.getlime.core.rest.model.base.entity.Error;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
 /**
  * Class representing an error response.
  *
@@ -38,7 +41,7 @@ public class ErrorResponse extends ObjectResponse<Error> {
      * @param code Error code.
      * @param message Error message.
      */
-    public ErrorResponse(String code, String message) {
+    public ErrorResponse(@NotBlank String code, String message) {
         super(Status.ERROR, new Error(code, message));
     }
 
@@ -49,7 +52,7 @@ public class ErrorResponse extends ObjectResponse<Error> {
      * @param code Error code.
      * @param t Throwable, whose message is used as an error message.
      */
-    public ErrorResponse(String code, Throwable t) {
+    public ErrorResponse(@NotBlank String code, Throwable t) {
         super(Status.ERROR, new Error(code, t != null ? t.getMessage() : null));
     }
 
@@ -58,7 +61,7 @@ public class ErrorResponse extends ObjectResponse<Error> {
      *
      * @param error Error response object.
      */
-    public ErrorResponse(Error error) {
+    public ErrorResponse(@NotNull Error error) {
         super(Status.ERROR, error);
     }
 

--- a/rest-model-base/src/main/java/io/getlime/core/rest/model/base/response/ObjectResponse.java
+++ b/rest-model-base/src/main/java/io/getlime/core/rest/model/base/response/ObjectResponse.java
@@ -16,6 +16,7 @@
 package io.getlime.core.rest.model.base.response;
 
 import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 
 /**
  * Generic response with status and object object of a custom class.
@@ -27,6 +28,7 @@ import javax.validation.Valid;
 public class ObjectResponse<T> extends Response {
 
     @Valid
+    @NotNull
     private T responseObject;
 
     /**

--- a/rest-model-base/src/main/java/io/getlime/core/rest/model/base/response/ObjectResponse.java
+++ b/rest-model-base/src/main/java/io/getlime/core/rest/model/base/response/ObjectResponse.java
@@ -15,6 +15,8 @@
  */
 package io.getlime.core.rest.model.base.response;
 
+import javax.validation.Valid;
+
 /**
  * Generic response with status and object object of a custom class.
  *
@@ -24,6 +26,7 @@ package io.getlime.core.rest.model.base.response;
  */
 public class ObjectResponse<T> extends Response {
 
+    @Valid
     private T responseObject;
 
     /**

--- a/rest-model-base/src/main/java/io/getlime/core/rest/model/base/response/Response.java
+++ b/rest-model-base/src/main/java/io/getlime/core/rest/model/base/response/Response.java
@@ -15,6 +15,8 @@
  */
 package io.getlime.core.rest.model.base.response;
 
+import javax.validation.constraints.NotBlank;
+
 /**
  * Simple status only response object.
  *
@@ -39,6 +41,7 @@ public class Response {
 
     }
 
+    @NotBlank
     protected String status;
 
     /**


### PR DESCRIPTION
This change will make the model work with standard validation API and we can avoid using custom validators.