### PR TITLE
Update dependencies and Migrate to WebClient version 5.3

### DIFF
--- a/rest-client-base/pom.xml
+++ b/rest-client-base/pom.xml
@@ -20,12 +20,12 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webflux</artifactId>
-            <version>2.3.10.RELEASE</version>
+            <version>2.4.5</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
-            <version>2.3.10.RELEASE</version>
+            <version>2.4.5</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/rest-client-base/src/main/java/com/wultra/core/rest/client/base/DefaultRestClient.java
+++ b/rest-client-base/src/main/java/com/wultra/core/rest/client/base/DefaultRestClient.java
@@ -468,10 +468,10 @@ public class DefaultRestClient implements RestClient {
     }
 
     /**
-     * Handle error response for non-blocking calls.
+     * Handle response using non-blocking calls.
      * @param response Client response.
      * @param responseType Expected response type.
-     * @return Exception created for the error response.
+     * @return Mono with response entity or error.
      */
     private <T> Mono<ResponseEntity<T>> handleResponse(ClientResponse response, ParameterizedTypeReference<T> responseType) {
         if (!response.statusCode().isError()) {

--- a/rest-client-base/src/main/java/com/wultra/core/rest/client/base/DefaultRestClient.java
+++ b/rest-client-base/src/main/java/com/wultra/core/rest/client/base/DefaultRestClient.java
@@ -38,10 +38,13 @@ import org.springframework.http.codec.json.Jackson2JsonEncoder;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.reactive.function.BodyInserters;
-import org.springframework.web.reactive.function.client.*;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunctions;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
+import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 import reactor.netty.http.client.HttpClient;
-import reactor.netty.tcp.ProxyProvider;
+import reactor.netty.transport.ProxyProvider;
 
 import javax.net.ssl.SSLException;
 import java.io.IOException;
@@ -119,28 +122,24 @@ public class DefaultRestClient implements RestClient {
         } catch (SSLException ex) {
             throw new RestClientException("SSL error occurred: " + ex.getMessage(), ex);
         }
-        httpClient = httpClient.tcpConfiguration(tcpClient -> {
-                            if (config.getConnectionTimeout() != null) {
-                                tcpClient = tcpClient.option(
-                                        ChannelOption.CONNECT_TIMEOUT_MILLIS,
-                                        config.getConnectionTimeout());
-                            }
-                            if (config.isProxyEnabled()) {
-                                tcpClient = tcpClient.proxy(proxySpec -> {
-                                    ProxyProvider.Builder proxyBuilder = proxySpec
-                                            .type(ProxyProvider.Proxy.HTTP)
-                                            .host(config.getProxyHost())
-                                            .port(config.getProxyPort());
-                                    if (config.getProxyUsername() != null && !config.getProxyUsername().isEmpty()) {
-                                        proxyBuilder.username(config.getProxyUsername());
-                                        proxyBuilder.password(s -> config.getProxyPassword());
-                                    }
-                                    proxyBuilder.build();
-                                });
-                            }
-                            return tcpClient;
-                        }
-                );
+        if (config.getConnectionTimeout() != null) {
+            httpClient.option(
+                    ChannelOption.CONNECT_TIMEOUT_MILLIS,
+                    config.getConnectionTimeout());
+        }
+        if (config.isProxyEnabled()) {
+            httpClient.proxy(proxySpec -> {
+                ProxyProvider.Builder proxyBuilder = proxySpec
+                        .type(ProxyProvider.Proxy.HTTP)
+                        .host(config.getProxyHost())
+                        .port(config.getProxyPort());
+                if (config.getProxyUsername() != null && !config.getProxyUsername().isEmpty()) {
+                    proxyBuilder.username(config.getProxyUsername());
+                    proxyBuilder.password(s -> config.getProxyPassword());
+                }
+                proxyBuilder.build();
+            });
+        }
 
         final ObjectMapper objectMapper = config.getObjectMapper();
         ExchangeStrategies exchangeStrategies = ExchangeStrategies.builder()
@@ -176,31 +175,30 @@ public class DefaultRestClient implements RestClient {
     @Override
     public <T> ResponseEntity<T> get(String path, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> headers, ParameterizedTypeReference<T> responseType) throws RestClientException {
         try {
-            ClientResponse response = buildUri(webClient.get(), path, queryParams)
+            return buildUri(webClient.get(), path, queryParams)
                     .headers(h -> {
                         if (headers != null) {
                             h.addAll(headers);
                         }
                     })
-                    .exchange()
+                    .exchangeToMono(rs -> handleResponse(rs, responseType))
                     .block();
-            validateResponse(response, responseType);
-            return response.toEntity(responseType).block();
-        } catch (RestClientException ex) {
-            // Rethrow validation errors
-            throw ex;
         } catch (Exception ex) {
+            if (ex.getCause() instanceof RestClientException) {
+                // Throw exceptions created by REST client
+                throw (RestClientException) ex.getCause();
+            }
             throw new RestClientException("HTTP GET request failed", ex);
         }
     }
 
     @Override
-    public void getNonBlocking(String path, Consumer<ClientResponse> onSuccess, Consumer<Throwable> onError) throws RestClientException {
-        getNonBlocking(path, null, null, onSuccess, onError);
+    public <T> void getNonBlocking(String path, ParameterizedTypeReference<T> responseType, Consumer<ResponseEntity<T>> onSuccess, Consumer<Throwable> onError) throws RestClientException {
+        getNonBlocking(path, null, null, responseType, onSuccess, onError);
     }
 
     @Override
-    public void getNonBlocking(String path, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> headers, Consumer<ClientResponse> onSuccess, Consumer<Throwable> onError) throws RestClientException {
+    public <T> void getNonBlocking(String path, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> headers, ParameterizedTypeReference<T> responseType, Consumer<ResponseEntity<T>> onSuccess, Consumer<Throwable> onError) throws RestClientException {
         try {
             buildUri(webClient.get(), path, queryParams)
                     .headers(h -> {
@@ -209,7 +207,7 @@ public class DefaultRestClient implements RestClient {
                         }
                     })
                     .accept(config.getAcceptType())
-                    .exchange()
+                    .exchangeToMono(rs -> handleResponse(rs, responseType))
                     .subscribe(onSuccess, onError);
         } catch (Exception ex) {
             throw new RestClientException("HTTP GET request failed", ex);
@@ -254,24 +252,25 @@ public class DefaultRestClient implements RestClient {
                     })
                     .contentType(config.getContentType())
                     .accept(config.getAcceptType());
-            ClientResponse response = buildResponseMono(spec, request).block();
-            validateResponse(response, responseType);
-            return response.toEntity(responseType).block();
-        } catch (RestClientException ex) {
-            // Rethrow validation errors
-            throw ex;
+            return buildRequest(spec, request)
+                    .exchangeToMono(rs -> handleResponse(rs, responseType))
+                    .block();
         } catch (Exception ex) {
+            if (ex.getCause() instanceof RestClientException) {
+                // Throw exceptions created by REST client
+                throw (RestClientException) ex.getCause();
+            }
             throw new RestClientException("HTTP POST request failed", ex);
         }
     }
 
     @Override
-    public void postNonBlocking(String path, Object request, Consumer<ClientResponse> onSuccess, Consumer<Throwable> onError) throws RestClientException {
-        postNonBlocking(path, request, null, null, onSuccess, onError);
+    public <T> void postNonBlocking(String path, Object request,  ParameterizedTypeReference<T> responseType, Consumer<ResponseEntity<T>> onSuccess, Consumer<Throwable> onError) throws RestClientException {
+        postNonBlocking(path, request, null, null, responseType, onSuccess, onError);
     }
 
     @Override
-    public void postNonBlocking(String path, Object request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> headers, Consumer<ClientResponse> onSuccess, Consumer<Throwable> onError) throws RestClientException {
+    public <T> void postNonBlocking(String path, Object request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> headers,  ParameterizedTypeReference<T> responseType, Consumer<ResponseEntity<T>> onSuccess, Consumer<Throwable> onError) throws RestClientException {
         try {
             WebClient.RequestBodySpec spec = buildUri(webClient.post(), path, queryParams)
                     .headers(h -> {
@@ -281,8 +280,9 @@ public class DefaultRestClient implements RestClient {
                     })
                     .contentType(config.getContentType())
                     .accept(config.getAcceptType());
-            Mono<ClientResponse> responseMono = buildResponseMono(spec, request);
-            responseMono.subscribe(onSuccess, onError);
+            buildRequest(spec, request)
+                    .exchangeToMono(rs -> handleResponse(rs, responseType))
+                    .subscribe(onSuccess, onError);
         } catch (Exception ex) {
             throw new RestClientException("HTTP POST request failed", ex);
         }
@@ -326,24 +326,25 @@ public class DefaultRestClient implements RestClient {
                     })
                     .contentType(config.getContentType())
                     .accept(config.getAcceptType());
-            ClientResponse response = buildResponseMono(spec, request).block();
-            validateResponse(response, responseType);
-            return response.toEntity(responseType).block();
-        } catch (RestClientException ex) {
-            // Rethrow validation errors
-            throw ex;
+            return buildRequest(spec, request)
+                    .exchangeToMono(rs -> handleResponse(rs, responseType))
+                    .block();
         } catch (Exception ex) {
+            if (ex.getCause() instanceof RestClientException) {
+                // Throw exceptions created by REST client
+                throw (RestClientException) ex.getCause();
+            }
             throw new RestClientException("HTTP PUT request failed", ex);
         }
     }
 
     @Override
-    public void putNonBlocking(String path, Object request, Consumer<ClientResponse> onSuccess, Consumer<Throwable> onError) throws RestClientException {
-        putNonBlocking(path, request, null, null, onSuccess, onError);
+    public <T> void putNonBlocking(String path, Object request,  ParameterizedTypeReference<T> responseType, Consumer<ResponseEntity<T>> onSuccess, Consumer<Throwable> onError) throws RestClientException {
+        putNonBlocking(path, request, null, null, responseType, onSuccess, onError);
     }
 
     @Override
-    public void putNonBlocking(String path, Object request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> headers, Consumer<ClientResponse> onSuccess, Consumer<Throwable> onError) throws RestClientException {
+    public <T> void putNonBlocking(String path, Object request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> headers,  ParameterizedTypeReference<T> responseType, Consumer<ResponseEntity<T>> onSuccess, Consumer<Throwable> onError) throws RestClientException {
         try {
             WebClient.RequestBodySpec spec = buildUri(webClient.put(), path, queryParams)
                     .headers(h -> {
@@ -353,8 +354,9 @@ public class DefaultRestClient implements RestClient {
                     })
                     .contentType(config.getContentType())
                     .accept(config.getAcceptType());
-            Mono<ClientResponse> responseMono = buildResponseMono(spec, request);
-            responseMono.subscribe(onSuccess, onError);
+            buildRequest(spec, request)
+                    .exchangeToMono(rs -> handleResponse(rs, responseType))
+                    .subscribe(onSuccess, onError);
         } catch (Exception ex) {
             throw new RestClientException("HTTP PUT request failed", ex);
         }
@@ -390,31 +392,30 @@ public class DefaultRestClient implements RestClient {
     @Override
     public <T> ResponseEntity<T> delete(String path, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> headers, ParameterizedTypeReference<T> responseType) throws RestClientException {
         try {
-            ClientResponse response = buildUri(webClient.delete(), path, queryParams)
+            return buildUri(webClient.delete(), path, queryParams)
                     .headers(h -> {
                         if (headers != null) {
                             h.addAll(headers);
                         }
                     })
-                    .exchange()
+                    .exchangeToMono(rs -> handleResponse(rs, responseType))
                     .block();
-            validateResponse(response, responseType);
-            return response.toEntity(responseType).block();
-        } catch (RestClientException ex) {
-            // Rethrow validation errors
-            throw ex;
         } catch (Exception ex) {
+            if (ex.getCause() instanceof RestClientException) {
+                // Throw exceptions created by REST client
+                throw (RestClientException) ex.getCause();
+            }
             throw new RestClientException("HTTP DELETE request failed", ex);
         }
     }
 
     @Override
-    public void deleteNonBlocking(String path, Consumer<ClientResponse> onSuccess, Consumer<Throwable> onError) throws RestClientException {
-        deleteNonBlocking(path, null, null, onSuccess, onError);
+    public <T> void deleteNonBlocking(String path,  ParameterizedTypeReference<T> responseType, Consumer<ResponseEntity<T>> onSuccess, Consumer<Throwable> onError) throws RestClientException {
+        deleteNonBlocking(path, null, null, responseType, onSuccess, onError);
     }
 
     @Override
-    public void deleteNonBlocking(String path, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> headers, Consumer<ClientResponse> onSuccess, Consumer<Throwable> onError) throws RestClientException {
+    public <T> void deleteNonBlocking(String path, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> headers, ParameterizedTypeReference<T> responseType, Consumer<ResponseEntity<T>> onSuccess, Consumer<Throwable> onError) throws RestClientException {
         try {
             buildUri(webClient.delete(), path, queryParams)
                     .headers(h -> {
@@ -423,7 +424,7 @@ public class DefaultRestClient implements RestClient {
                         }
                     })
                     .accept(config.getAcceptType())
-                    .exchange()
+                    .exchangeToMono(rs -> handleResponse(rs, responseType))
                     .subscribe(onSuccess, onError);
         } catch (Exception ex) {
             throw new RestClientException("HTTP DELETE request failed", ex);
@@ -467,20 +468,18 @@ public class DefaultRestClient implements RestClient {
     }
 
     /**
-     * Validate response and response type.
+     * Handle error response for non-blocking calls.
      * @param response Client response.
-     * @param responseType Response type.
-     * @throws RestClientException Thrown in case validation fails.
+     * @param responseType Expected response type.
+     * @return Exception created for the error response.
      */
-    private void validateResponse(ClientResponse response, ParameterizedTypeReference<?> responseType) throws RestClientException {
-        if (response == null) {
-            throw new RestClientException("Missing response");
+    private <T> Mono<ResponseEntity<T>> handleResponse(ClientResponse response, ParameterizedTypeReference<T> responseType) {
+        if (!response.statusCode().isError()) {
+            // OK response
+            return response.toEntity(responseType);
         }
-        if (responseType == null) {
-            throw new RestClientException("Missing response type");
-        }
-        if (response.statusCode().isError()) {
-            ResponseEntity<String> rawResponseEntity = response.toEntity(String.class).block();
+        // Error handling
+        return response.toEntity(String.class).flatMap(rawResponseEntity -> {
             String rawResponse = null;
             HttpHeaders rawResponseHeaders = null;
             if (rawResponseEntity != null) {
@@ -495,14 +494,14 @@ public class DefaultRestClient implements RestClient {
                     ObjectMapper objectMapper = new ObjectMapper();
                     ErrorResponse errorResponse = objectMapper.readValue(rawResponse, ErrorResponse.class);
                     if (errorResponse != null) {
-                        throw new RestClientException("HTTP error occurred: " + response.statusCode(), response.statusCode(), rawResponse, rawResponseHeaders, errorResponse);
+                        return Mono.error(new RestClientException("HTTP error occurred: " + response.statusCode(), response.statusCode(), rawResponse, rawResponseHeaders, errorResponse));
                     }
                 } catch (IOException ex) {
                     // Exception is handled silently, ErrorResponse is not available, use a regular error with raw response
                 }
             }
-            throw new RestClientException("HTTP error occurred: " + response.statusCode(), response.statusCode(), rawResponse, rawResponseHeaders);
-        }
+            return Mono.error(new RestClientException("HTTP error occurred: " + response.statusCode(), response.statusCode(), rawResponse, rawResponseHeaders));
+        });
     }
 
     /**
@@ -544,20 +543,20 @@ public class DefaultRestClient implements RestClient {
     }
 
     /**
-     * Build response Mono for given request specification.
-     * @param requestSpec Request specification.
+     * Build request for various request types.
+     * @param requestSpec Request body specification.
      * @param request Request data.
-     * @return Mono with ClientResponse.
+     * @return Updated header specification.
      */
     @SuppressWarnings("unchecked")
-    private Mono<ClientResponse> buildResponseMono(WebClient.RequestBodySpec requestSpec, Object request) {
+    private WebClient.RequestHeadersSpec<?> buildRequest(WebClient.RequestBodySpec requestSpec, Object request) {
         if (request != null) {
             if (request instanceof Publisher) {
-                return requestSpec.body(BodyInserters.fromDataBuffers((Publisher<DataBuffer>) request)).exchange();
+                return requestSpec.body(BodyInserters.fromDataBuffers((Publisher<DataBuffer>) request));
             }
-            return requestSpec.body(BodyInserters.fromValue(request)).exchange();
+            return requestSpec.body(BodyInserters.fromValue(request));
         } else {
-            return requestSpec.exchange();
+            return requestSpec;
         }
     }
 

--- a/rest-client-base/src/main/java/com/wultra/core/rest/client/base/RestClient.java
+++ b/rest-client-base/src/main/java/com/wultra/core/rest/client/base/RestClient.java
@@ -21,7 +21,6 @@ import io.getlime.core.rest.model.base.response.Response;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.MultiValueMap;
-import org.springframework.web.reactive.function.client.ClientResponse;
 
 import java.util.function.Consumer;
 
@@ -57,22 +56,24 @@ public interface RestClient {
     /**
      * Execute a non-blocking HTTP GET request.
      * @param path Request path.
+     * @param responseType Parameterized response type.
      * @param onSuccess Consumer used in case of success.
      * @param onError Consumer used in case of failure.
      * @throws RestClientException Thrown in case HTTP GET request fails.
      */
-    void getNonBlocking(String path, Consumer<ClientResponse> onSuccess, Consumer<Throwable> onError) throws RestClientException;
+    <T> void getNonBlocking(String path, ParameterizedTypeReference<T> responseType, Consumer<ResponseEntity<T>> onSuccess, Consumer<Throwable> onError) throws RestClientException;
 
     /**
      * Execute a non-blocking HTTP GET request with specified HTTP headers.
      * @param path Request path.
      * @param queryParams Query parameters.
      * @param headers HTTP headers.
+     * @param responseType Parameterized response type.
      * @param onSuccess Consumer used in case of success.
      * @param onError Consumer used in case of failure.
      * @throws RestClientException Thrown in case HTTP GET request fails.
      */
-    void getNonBlocking(String path, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> headers, Consumer<ClientResponse> onSuccess, Consumer<Throwable> onError) throws RestClientException;
+    <T> void getNonBlocking(String path, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> headers, ParameterizedTypeReference<T> responseType, Consumer<ResponseEntity<T>> onSuccess, Consumer<Throwable> onError) throws RestClientException;
 
     /**
      * Execute a blocking HTTP GET request with ObjectRequest / Response types.
@@ -142,11 +143,12 @@ public interface RestClient {
      * Execute a non-blocking HTTP POST request.
      * @param path Request path.
      * @param request Request object.
+     * @param responseType Parameterized response type.
      * @param onSuccess Consumer used in case of success.
      * @param onError Consumer used in case of failure.
      * @throws RestClientException Thrown in case HTTP POST request fails.
      */
-    void postNonBlocking(String path, Object request, Consumer<ClientResponse> onSuccess, Consumer<Throwable> onError) throws RestClientException;
+    <T> void postNonBlocking(String path, Object request, ParameterizedTypeReference<T> responseType, Consumer<ResponseEntity<T>> onSuccess, Consumer<Throwable> onError) throws RestClientException;
 
     /**
      * Execute a non-blocking HTTP POST request with specified HTTP headers.
@@ -154,11 +156,12 @@ public interface RestClient {
      * @param request Request object.
      * @param queryParams Query parameters.
      * @param headers HTTP headers.
+     * @param responseType Parameterized response type.
      * @param onSuccess Consumer used in case of success.
      * @param onError Consumer used in case of failure.
      * @throws RestClientException Thrown in case HTTP POST request fails.
      */
-    void postNonBlocking(String path, Object request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> headers, Consumer<ClientResponse> onSuccess, Consumer<Throwable> onError) throws RestClientException;
+    <T> void postNonBlocking(String path, Object request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> headers, ParameterizedTypeReference<T> responseType, Consumer<ResponseEntity<T>> onSuccess, Consumer<Throwable> onError) throws RestClientException;
 
     /**
      * Execute a blocking HTTP POST request with ObjectRequest / Response types.
@@ -232,11 +235,12 @@ public interface RestClient {
      * Execute a non-blocking HTTP PUT request.
      * @param path Request path.
      * @param request Request object.
+     * @param responseType Parameterized response type.
      * @param onSuccess Consumer used in case of success.
      * @param onError Consumer used in case of failure.
      * @throws RestClientException Thrown in case HTTP PUT request fails.
      */
-    void putNonBlocking(String path, Object request, Consumer<ClientResponse> onSuccess, Consumer<Throwable> onError) throws RestClientException;
+    <T> void putNonBlocking(String path, Object request, ParameterizedTypeReference<T> responseType, Consumer<ResponseEntity<T>> onSuccess, Consumer<Throwable> onError) throws RestClientException;
 
     /**
      * Execute a non-blocking HTTP PUT request with specified HTTP headers.
@@ -244,11 +248,12 @@ public interface RestClient {
      * @param request Request object.
      * @param queryParams Query parameters.
      * @param headers HTTP headers.
+     * @param responseType Parameterized response type.
      * @param onSuccess Consumer used in case of success.
      * @param onError Consumer used in case of failure.
      * @throws RestClientException Thrown in case HTTP PUT request fails.
      */
-    void putNonBlocking(String path, Object request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> headers, Consumer<ClientResponse> onSuccess, Consumer<Throwable> onError) throws RestClientException;
+    <T> void putNonBlocking(String path, Object request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> headers, ParameterizedTypeReference<T> responseType, Consumer<ResponseEntity<T>> onSuccess, Consumer<Throwable> onError) throws RestClientException;
 
     /**
      * Execute a blocking HTTP PUT request with ObjectRequest / Response types.
@@ -319,22 +324,24 @@ public interface RestClient {
     /**
      * Execute a non-blocking HTTP DELETE request.
      * @param path Request path.
+     * @param responseType Parameterized response type.
      * @param onSuccess Consumer used in case of success.
      * @param onError Consumer used in case of failure.
      * @throws RestClientException Thrown in case HTTP DELETE request fails.
      */
-    void deleteNonBlocking(String path, Consumer<ClientResponse> onSuccess, Consumer<Throwable> onError) throws RestClientException;
+    <T> void deleteNonBlocking(String path, ParameterizedTypeReference<T> responseType, Consumer<ResponseEntity<T>> onSuccess, Consumer<Throwable> onError) throws RestClientException;
 
     /**
      * Execute a non-blocking HTTP DELETE request with specified HTTP headers.
      * @param path Request path.
      * @param queryParams Query parameters.
      * @param headers HTTP headers.
+     * @param responseType Parameterized response type.
      * @param onSuccess Consumer used in case of success.
      * @param onError Consumer used in case of failure.
      * @throws RestClientException Thrown in case HTTP DELETE request fails.
      */
-    void deleteNonBlocking(String path, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> headers, Consumer<ClientResponse> onSuccess, Consumer<Throwable> onError) throws RestClientException;
+    <T> void deleteNonBlocking(String path, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> headers, ParameterizedTypeReference<T> responseType, Consumer<ResponseEntity<T>> onSuccess, Consumer<Throwable> onError) throws RestClientException;
 
     /**
      * Execute a blocking HTTP DELETE request with ObjectRequest / Response types.

--- a/rest-client-base/src/test/java/com/wultra/core/rest/client/base/DefaultRestClientTest.java
+++ b/rest-client-base/src/test/java/com/wultra/core/rest/client/base/DefaultRestClientTest.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wultra.core.rest.client.base.model.TestRequest;
 import com.wultra.core.rest.client.base.model.TestResponse;
 import io.getlime.core.rest.model.base.request.ObjectRequest;
-import io.getlime.core.rest.model.base.response.ErrorResponse;
 import io.getlime.core.rest.model.base.response.ObjectResponse;
 import io.getlime.core.rest.model.base.response.Response;
 import org.junit.Assert;
@@ -34,7 +33,6 @@ import org.springframework.core.io.buffer.DefaultDataBuffer;
 import org.springframework.core.io.buffer.DefaultDataBufferFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.web.reactive.function.client.ClientResponse;
 import reactor.core.publisher.Flux;
 
 import java.nio.ByteBuffer;
@@ -83,16 +81,14 @@ public class DefaultRestClientTest {
     @Test
     public void testGetWithResponseNonBlocking() throws RestClientException, InterruptedException {
         CountDownLatch countDownLatch = new CountDownLatch(1);
-        Consumer<ClientResponse> onSuccess = response -> {
-            response.toEntity(Response.class).subscribe(responseEntity -> {
-                assertNotNull(responseEntity);
-                assertNotNull(responseEntity.getBody());
-                assertEquals("OK", responseEntity.getBody().getStatus());
-                countDownLatch.countDown();
-            });
+        Consumer<ResponseEntity<Response>> onSuccess = responseEntity -> {
+            assertNotNull(responseEntity);
+            assertNotNull(responseEntity.getBody());
+            assertEquals("OK", responseEntity.getBody().getStatus());
+            countDownLatch.countDown();
         };
         Consumer<Throwable> onError = error -> Assert.fail(error.getMessage());
-        restClient.getNonBlocking("/response", onSuccess, onError);
+        restClient.getNonBlocking("/response", new ParameterizedTypeReference<Response>(){}, onSuccess, onError);
         assertTrue(countDownLatch.await(SYNCHRONIZATION_TIMEOUT, TimeUnit.MILLISECONDS));
     }
 
@@ -135,16 +131,14 @@ public class DefaultRestClientTest {
     @Test
     public void testPostWithResponseNonBlocking() throws RestClientException, InterruptedException {
         CountDownLatch countDownLatch = new CountDownLatch(1);
-        Consumer<ClientResponse> onSuccess = response -> {
-            response.toEntity(Response.class).subscribe(responseEntity -> {
-                assertNotNull(responseEntity);
-                assertNotNull(responseEntity.getBody());
-                assertEquals("OK", responseEntity.getBody().getStatus());
-                countDownLatch.countDown();
-            });
+        Consumer<ResponseEntity<Response>> onSuccess = responseEntity -> {
+            assertNotNull(responseEntity);
+            assertNotNull(responseEntity.getBody());
+            assertEquals("OK", responseEntity.getBody().getStatus());
+            countDownLatch.countDown();
         };
         Consumer<Throwable> onError = error -> Assert.fail(error.getMessage());
-        restClient.postNonBlocking("/response", null, onSuccess, onError);
+        restClient.postNonBlocking("/response", null, new ParameterizedTypeReference<Response>(){}, onSuccess, onError);
         assertTrue(countDownLatch.await(SYNCHRONIZATION_TIMEOUT, TimeUnit.MILLISECONDS));
     }
 
@@ -196,17 +190,15 @@ public class DefaultRestClientTest {
         CountDownLatch countDownLatch = new CountDownLatch(1);
         String requestData = String.valueOf(System.currentTimeMillis());
         ObjectRequest<TestRequest> request = new ObjectRequest<>(new TestRequest(requestData));
-        Consumer<ClientResponse> onSuccess = response -> {
-            response.toEntity(new ParameterizedTypeReference<ObjectResponse<TestResponse>>(){}).subscribe(responseEntity -> {
-                assertNotNull(responseEntity);
-                assertNotNull(responseEntity.getBody());
-                assertNotNull(responseEntity.getBody().getResponseObject());
-                assertEquals("OK", responseEntity.getBody().getStatus());
-                countDownLatch.countDown();
-            });
+        Consumer<ResponseEntity<ObjectResponse<TestResponse>>> onSuccess = responseEntity -> {
+            assertNotNull(responseEntity);
+            assertNotNull(responseEntity.getBody());
+            assertNotNull(responseEntity.getBody().getResponseObject());
+            assertEquals("OK", responseEntity.getBody().getStatus());
+            countDownLatch.countDown();
         };
         Consumer<Throwable> onError = error -> Assert.fail(error.getMessage());
-        restClient.postNonBlocking("/object-request-response", request, onSuccess, onError);
+        restClient.postNonBlocking("/object-request-response", request, new ParameterizedTypeReference<ObjectResponse<TestResponse>>(){}, onSuccess, onError);
         assertTrue(countDownLatch.await(SYNCHRONIZATION_TIMEOUT, TimeUnit.MILLISECONDS));
     }
 
@@ -227,16 +219,14 @@ public class DefaultRestClientTest {
     @Test
     public void testPutWithResponseNonBlocking() throws RestClientException, InterruptedException {
         CountDownLatch countDownLatch = new CountDownLatch(1);
-        Consumer<ClientResponse> onSuccess = response -> {
-            response.toEntity(Response.class).subscribe(responseEntity -> {
-                assertNotNull(responseEntity);
-                assertNotNull(responseEntity.getBody());
-                assertEquals("OK", responseEntity.getBody().getStatus());
-                countDownLatch.countDown();
-            });
+        Consumer<ResponseEntity<Response>> onSuccess = responseEntity -> {
+            assertNotNull(responseEntity);
+            assertNotNull(responseEntity.getBody());
+            assertEquals("OK", responseEntity.getBody().getStatus());
+            countDownLatch.countDown();
         };
         Consumer<Throwable> onError = error -> Assert.fail(error.getMessage());
-        restClient.putNonBlocking("/response", null, onSuccess, onError);
+        restClient.putNonBlocking("/response", null, new ParameterizedTypeReference<Response>(){}, onSuccess, onError);
         assertTrue(countDownLatch.await(SYNCHRONIZATION_TIMEOUT, TimeUnit.MILLISECONDS));
     }
 
@@ -288,17 +278,15 @@ public class DefaultRestClientTest {
         CountDownLatch countDownLatch = new CountDownLatch(1);
         String requestData = String.valueOf(System.currentTimeMillis());
         ObjectRequest<TestRequest> request = new ObjectRequest<>(new TestRequest(requestData));
-        Consumer<ClientResponse> onSuccess = response -> {
-            response.toEntity(new ParameterizedTypeReference<ObjectResponse<TestResponse>>(){}).subscribe(responseEntity -> {
-                assertNotNull(responseEntity);
-                assertNotNull(responseEntity.getBody());
-                assertNotNull(responseEntity.getBody().getResponseObject());
-                assertEquals("OK", responseEntity.getBody().getStatus());
-                countDownLatch.countDown();
-            });
+        Consumer<ResponseEntity<ObjectResponse<TestResponse>>> onSuccess = responseEntity -> {
+            assertNotNull(responseEntity);
+            assertNotNull(responseEntity.getBody());
+            assertNotNull(responseEntity.getBody().getResponseObject());
+            assertEquals("OK", responseEntity.getBody().getStatus());
+            countDownLatch.countDown();
         };
         Consumer<Throwable> onError = error -> Assert.fail(error.getMessage());
-        restClient.putNonBlocking("/object-request-response", request, onSuccess, onError);
+        restClient.putNonBlocking("/object-request-response", request, new ParameterizedTypeReference<ObjectResponse<TestResponse>>(){}, onSuccess, onError);
         assertTrue(countDownLatch.await(SYNCHRONIZATION_TIMEOUT, TimeUnit.MILLISECONDS));
     }
 
@@ -319,16 +307,14 @@ public class DefaultRestClientTest {
     @Test
     public void testDeleteWithResponseNonBlocking() throws RestClientException, InterruptedException {
         CountDownLatch countDownLatch = new CountDownLatch(1);
-        Consumer<ClientResponse> onSuccess = response -> {
-            response.toEntity(Response.class).subscribe(responseEntity -> {
-                assertNotNull(responseEntity);
-                assertNotNull(responseEntity.getBody());
-                assertEquals("OK", responseEntity.getBody().getStatus());
-                countDownLatch.countDown();
-            });
+        Consumer<ResponseEntity<Response>> onSuccess = responseEntity -> {
+            assertNotNull(responseEntity);
+            assertNotNull(responseEntity.getBody());
+            assertEquals("OK", responseEntity.getBody().getStatus());
+            countDownLatch.countDown();
         };
         Consumer<Throwable> onError = error -> Assert.fail(error.getMessage());
-        restClient.deleteNonBlocking("/response", onSuccess, onError);
+        restClient.deleteNonBlocking("/response", new ParameterizedTypeReference<Response>(){}, onSuccess, onError);
         assertTrue(countDownLatch.await(SYNCHRONIZATION_TIMEOUT, TimeUnit.MILLISECONDS));
     }
 
@@ -385,19 +371,18 @@ public class DefaultRestClientTest {
     @Test
     public void testPostWithErrorResponseNonBlocking() throws RestClientException, InterruptedException {
         CountDownLatch countDownLatch = new CountDownLatch(1);
-        Consumer<ClientResponse> onSuccess = response -> {
-            assertEquals(400, response.rawStatusCode());
-            response.toEntity(ErrorResponse.class).subscribe(errorResponse -> {
-                assertNotNull(errorResponse);
-                assertNotNull(errorResponse.getBody());
-                assertEquals("ERROR", errorResponse.getBody().getStatus());
-                assertEquals("TEST_CODE", errorResponse.getBody().getResponseObject().getCode());
-                assertEquals("Test message", errorResponse.getBody().getResponseObject().getMessage());
-                countDownLatch.countDown();
-            });
+        Consumer<ResponseEntity<ObjectResponse<TestResponse>>> onSuccess = okResponse -> Assert.fail();
+        Consumer<Throwable> onError = error -> {
+            RestClientException ex = (RestClientException) error;
+            assertEquals(400, ex.getStatusCode().value());
+            assertEquals("{\"status\":\"ERROR\",\"responseObject\":{\"code\":\"TEST_CODE\",\"message\":\"Test message\"}}", ex.getResponse());
+            assertNotNull(ex.getErrorResponse());
+            assertEquals("ERROR", ex.getErrorResponse().getStatus());
+            assertEquals("TEST_CODE", ex.getErrorResponse().getResponseObject().getCode());
+            assertEquals("Test message", ex.getErrorResponse().getResponseObject().getMessage());
+            countDownLatch.countDown();
         };
-        Consumer<Throwable> onError = error -> Assert.fail(error.getMessage());
-        restClient.postNonBlocking("/error-response", null, onSuccess, onError);
+        restClient.postNonBlocking("/error-response", null, new ParameterizedTypeReference<ObjectResponse<TestResponse>>(){}, onSuccess, onError);
         assertTrue(countDownLatch.await(SYNCHRONIZATION_TIMEOUT, TimeUnit.MILLISECONDS));
     }
 


### PR DESCRIPTION
Fix of deprecations in WebClient:
- `exchange` -> `exchangeToMono`
- `httpClient.tcpConfiguration` -> `httpClient`

The biggest change is in non-blocking calls which require response type and return `ResponseEntity<T>` instead of `ClientResponse`. I added error handling into asynchronous methods to simplify usage of the REST client, it is no longer necessary to check for errors in the `onSuccess` consumer and `RestClientException` is received in the `onError` consumer.