### PR TITLE
Add builder for audit details to allow specifying audit type together with param, code cleanup

### DIFF
--- a/audit-base/pom.xml
+++ b/audit-base/pom.xml
@@ -51,6 +51,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>2.5.0</version>
                 <executions>
                     <execution>
                         <id>build-info</id>

--- a/audit-base/src/main/java/com/wultra/core/audit/base/Audit.java
+++ b/audit-base/src/main/java/com/wultra/core/audit/base/Audit.java
@@ -15,9 +15,8 @@
  */
 package com.wultra.core.audit.base;
 
+import com.wultra.core.audit.base.model.AuditDetail;
 import com.wultra.core.audit.base.model.AuditLevel;
-
-import java.util.Map;
 
 /**
  * Audit interface.
@@ -54,17 +53,17 @@ public interface Audit {
     /**
      * Create an error audit record.
      * @param message Error message.
-     * @param param Error message parameters.
+     * @param detail Detailed audit information.
      */
-    void error(String message, Map<String, Object> param);
+    void error(String message, AuditDetail detail);
 
     /**
      * Create an error audit record.
      * @param message Error message pattern.
-     * @param param Error message parameters.
+     * @param detail Detailed audit information.
      * @param args Error message arguments.
      */
-    void error(String message, Map<String, Object> param, Object ... args);
+    void error(String message, AuditDetail detail, Object ... args);
 
     /**
      * Get whether warning auditing is enabled.
@@ -88,17 +87,17 @@ public interface Audit {
     /**
      * Create a warning audit record.
      * @param message Warning message.
-     * @param param Warning message parameters.
+     * @param detail Detailed audit information.
      */
-    void warn(String message, Map<String, Object> param);
+    void warn(String message, AuditDetail detail);
 
     /**
      * Create a warning audit record.
      * @param message Warning message pattern.
-     * @param param Warning message parameters.
+     * @param detail Detailed audit information.
      * @param args Warning message arguments.
      */
-    void warn(String message, Map<String, Object> param, Object ... args);
+    void warn(String message, AuditDetail detail, Object ... args);
 
     /**
      * Get whether informational auditing is enabled.
@@ -122,17 +121,17 @@ public interface Audit {
     /**
      * Create an informational audit record.
      * @param message Informational message.
-     * @param param Informational message parameters.
+     * @param detail Detailed audit information.
      */
-    void info(String message, Map<String, Object> param);
+    void info(String message, AuditDetail detail);
 
     /**
      * Create an informational audit record.
      * @param message Informational message pattern.
-     * @param param Informational message parameters.
+     * @param detail Detailed audit information.
      * @param args Informational message arguments.
      */
-    void info(String message, Map<String, Object> param, Object ... args);
+    void info(String message, AuditDetail detail, Object ... args);
 
     /**
      * Get whether debug auditing is enabled.
@@ -156,17 +155,17 @@ public interface Audit {
     /**
      * Create a debug audit record.
      * @param message Debug message.
-     * @param param Debug message parameters.
+     * @param detail Detailed audit information.
      */
-    void debug(String message, Map<String, Object> param);
+    void debug(String message, AuditDetail detail);
 
     /**
      * Create a debug audit record.
      * @param message Debug message pattern.
-     * @param param Debug message parameters.
+     * @param detail Detailed audit information.
      * @param args Debug message arguments.
      */
-    void debug(String message, Map<String, Object> param, Object ... args);
+    void debug(String message, AuditDetail detail, Object ... args);
 
     /**
      * Get whether trace auditing is enabled.
@@ -190,17 +189,17 @@ public interface Audit {
     /**
      * Create a trace audit record.
      * @param message Trace message.
-     * @param param Trace message parameters.
+     * @param detail Detailed audit information.
      */
-    void trace(String message, Map<String, Object> param);
+    void trace(String message, AuditDetail detail);
 
     /**
      * Create a trace audit record.
      * @param message Trace message.
-     * @param param Trace message parameters.
+     * @param detail Detailed audit information.
      * @param args Trace message arguments.
      */
-    void trace(String message, Map<String, Object> param, Object ... args);
+    void trace(String message, AuditDetail detail, Object ... args);
 
     /**
      * Get whether specified auditing level is enabled.
@@ -228,18 +227,18 @@ public interface Audit {
      * Create an audit record.
      * @param message Audit message.
      * @param level Audit level.
-     * @param param Audit parameters.
+     * @param detail Detailed audit information.
      */
-    void log(String message, AuditLevel level, Map<String, Object> param);
+    void log(String message, AuditLevel level, AuditDetail detail);
 
     /**
      * Crate an audit record.
      * @param message Audit message pattern.
      * @param level Audit level.
-     * @param param Audit parameters.
+     * @param detail Detailed audit information.
      * @param args Audit message arguments.
      */
-    void log(String message, AuditLevel level, Map<String, Object> param, Object ... args);
+    void log(String message, AuditLevel level, AuditDetail detail, Object ... args);
 
     /**
      * Flush the audit record queue.

--- a/audit-base/src/main/java/com/wultra/core/audit/base/database/DatabaseAudit.java
+++ b/audit-base/src/main/java/com/wultra/core/audit/base/database/DatabaseAudit.java
@@ -18,14 +18,12 @@ package com.wultra.core.audit.base.database;
 import com.wultra.core.audit.base.Audit;
 import com.wultra.core.audit.base.AuditWriter;
 import com.wultra.core.audit.base.configuration.AuditConfiguration;
+import com.wultra.core.audit.base.model.AuditDetail;
 import com.wultra.core.audit.base.model.AuditLevel;
 import com.wultra.core.audit.base.model.AuditRecord;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Service;
-
-import java.util.Collections;
-import java.util.Map;
 
 /**
  * Database audit implementation.
@@ -56,29 +54,29 @@ public class DatabaseAudit implements Audit {
 
     @Override
     public void error(String message) {
-        errorInternal(message, Collections.emptyMap(), null);
+        errorInternal(message, new AuditDetail(), null);
     }
 
     @Override
     public void error(String message, Object... args) {
-        errorInternal(message, Collections.emptyMap(), args);
+        errorInternal(message, new AuditDetail(), args);
     }
 
     @Override
-    public void error(String message, Map<String, Object> param) {
-        errorInternal(message, param, null);
+    public void error(String message, AuditDetail detail) {
+        errorInternal(message, detail, null);
     }
 
     @Override
-    public void error(String message, Map<String, Object> param, Object... args) {
-        errorInternal(message, param, args);
+    public void error(String message, AuditDetail detail, Object... args) {
+        errorInternal(message, detail, args);
     }
 
-    private void errorInternal(String message, Map<String, Object> param, Object[] args) {
+    private void errorInternal(String message, AuditDetail detail, Object[] args) {
         if (!isErrorEnabled()) {
             return;
         }
-        final AuditRecord auditRecord = new AuditRecord(message, AuditLevel.ERROR, param, args);
+        final AuditRecord auditRecord = new AuditRecord(message, AuditLevel.ERROR, detail.getType(), detail.getParam(), args);
         writer.write(auditRecord);
     }
 
@@ -89,29 +87,29 @@ public class DatabaseAudit implements Audit {
 
     @Override
     public void warn(String message) {
-        warnInternal(message, Collections.emptyMap(), null);
+        warnInternal(message, new AuditDetail(), null);
     }
 
     @Override
     public void warn(String message, Object... args) {
-        warnInternal(message, Collections.emptyMap(), args);
+        warnInternal(message, new AuditDetail(), args);
     }
 
     @Override
-    public void warn(String message, Map<String, Object> param) {
-        warnInternal(message, param, null);
+    public void warn(String message, AuditDetail detail) {
+        warnInternal(message, detail, null);
     }
 
     @Override
-    public void warn(String message, Map<String, Object> param, Object... args) {
-        warnInternal(message, param, args);
+    public void warn(String message, AuditDetail detail, Object... args) {
+        warnInternal(message, detail, args);
     }
 
-    private void warnInternal(String message, Map<String, Object> param, Object[] args) {
+    private void warnInternal(String message, AuditDetail detail, Object[] args) {
         if (!isWarnEnabled()) {
             return;
         }
-        final AuditRecord auditRecord = new AuditRecord(message, AuditLevel.WARN, param, args);
+        final AuditRecord auditRecord = new AuditRecord(message, AuditLevel.WARN, detail.getType(), detail.getParam(), args);
         writer.write(auditRecord);
     }
 
@@ -122,29 +120,29 @@ public class DatabaseAudit implements Audit {
 
     @Override
     public void info(String message) {
-        infoInternal(message, Collections.emptyMap(), null);
+        infoInternal(message, new AuditDetail(), null);
     }
 
     @Override
     public void info(String message, Object... args) {
-        infoInternal(message, Collections.emptyMap(), args);
+        infoInternal(message, new AuditDetail(), args);
     }
 
     @Override
-    public void info(String message, Map<String, Object> param) {
-        infoInternal(message, param, null);
+    public void info(String message, AuditDetail detail) {
+        infoInternal(message, detail, null);
     }
 
     @Override
-    public void info(String message, Map<String, Object> param, Object... args) {
-        infoInternal(message, param, args);
+    public void info(String message, AuditDetail detail, Object... args) {
+        infoInternal(message, detail, args);
     }
 
-    private void infoInternal(String message, Map<String, Object> param, Object[] args) {
+    private void infoInternal(String message, AuditDetail detail, Object[] args) {
         if (!isInfoEnabled()) {
             return;
         }
-        final AuditRecord auditRecord = new AuditRecord(message, AuditLevel.INFO, param, args);
+        final AuditRecord auditRecord = new AuditRecord(message, AuditLevel.INFO, detail.getType(), detail.getParam(), args);
         writer.write(auditRecord);
     }
 
@@ -155,29 +153,29 @@ public class DatabaseAudit implements Audit {
 
     @Override
     public void debug(String message) {
-        debugInternal(message, Collections.emptyMap(), null);
+        debugInternal(message, new AuditDetail(), null);
     }
 
     @Override
     public void debug(String message, Object... args) {
-        debugInternal(message, Collections.emptyMap(), args);
+        debugInternal(message, new AuditDetail(), args);
     }
 
     @Override
-    public void debug(String message, Map<String, Object> param) {
-        debugInternal(message, param, null);
+    public void debug(String message, AuditDetail detail) {
+        debugInternal(message, detail, null);
     }
 
     @Override
-    public void debug(String message, Map<String, Object> param, Object... args) {
-        debugInternal(message, param, args);
+    public void debug(String message, AuditDetail detail, Object... args) {
+        debugInternal(message, detail, args);
     }
 
-    private void debugInternal(String message, Map<String, Object> param, Object[] args) {
+    private void debugInternal(String message, AuditDetail detail, Object[] args) {
         if (!isDebugEnabled()) {
             return;
         }
-        final AuditRecord auditRecord = new AuditRecord(message, AuditLevel.DEBUG, param, args);
+        final AuditRecord auditRecord = new AuditRecord(message, AuditLevel.DEBUG, detail.getType(), detail.getParam(), args);
         writer.write(auditRecord);
     }
 
@@ -188,29 +186,29 @@ public class DatabaseAudit implements Audit {
 
     @Override
     public void trace(String message) {
-        traceInternal(message, Collections.emptyMap(), null);
+        traceInternal(message, new AuditDetail(), null);
     }
 
     @Override
     public void trace(String message, Object... args) {
-        traceInternal(message, Collections.emptyMap(), args);
+        traceInternal(message, new AuditDetail(), args);
     }
 
     @Override
-    public void trace(String message, Map<String, Object> param) {
-        traceInternal(message, param, null);
+    public void trace(String message, AuditDetail detail) {
+        traceInternal(message, detail, null);
     }
 
     @Override
-    public void trace(String message, Map<String, Object> param, Object... args) {
-        traceInternal(message, param, args);
+    public void trace(String message, AuditDetail detail, Object... args) {
+        traceInternal(message, detail, args);
     }
 
-    private void traceInternal(String message, Map<String, Object> param, Object[] args) {
+    private void traceInternal(String message, AuditDetail detail, Object[] args) {
         if (!isTraceEnabled()) {
             return;
         }
-        final AuditRecord auditRecord = new AuditRecord(message, AuditLevel.TRACE, param, args);
+        final AuditRecord auditRecord = new AuditRecord(message, AuditLevel.TRACE, detail.getType(), detail.getParam(), args);
         writer.write(auditRecord);
     }
 
@@ -221,29 +219,29 @@ public class DatabaseAudit implements Audit {
 
     @Override
     public void log(String message, AuditLevel level) {
-        logInternal(message, level, Collections.emptyMap(), null);
+        logInternal(message, level, new AuditDetail(), null);
     }
 
     @Override
     public void log(String message, AuditLevel level, Object... args) {
-        logInternal(message, level, Collections.emptyMap(), args);
+        logInternal(message, level, new AuditDetail(), args);
     }
 
     @Override
-    public void log(String message, AuditLevel level, Map<String, Object> param) {
-        logInternal(message, level, param, null);
+    public void log(String message, AuditLevel level, AuditDetail detail) {
+        logInternal(message, level, detail, null);
     }
 
     @Override
-    public void log(String message, AuditLevel level, Map<String, Object> param, Object... args) {
-        logInternal(message, level, param, args);
+    public void log(String message, AuditLevel level, AuditDetail detail, Object... args) {
+        logInternal(message, level, detail, args);
     }
 
-    private void logInternal(String message, AuditLevel level, Map<String, Object> param, Object[] args) {
+    private void logInternal(String message, AuditLevel level, AuditDetail detail, Object[] args) {
         if (!isLevelEnabled(level)) {
             return;
         }
-        final AuditRecord auditRecord = new AuditRecord(message, level, param, args);
+        final AuditRecord auditRecord = new AuditRecord(message, level, detail.getType(), detail.getParam(), args);
         writer.write(auditRecord);
     }
 

--- a/audit-base/src/main/java/com/wultra/core/audit/base/database/DatabaseAuditWriter.java
+++ b/audit-base/src/main/java/com/wultra/core/audit/base/database/DatabaseAuditWriter.java
@@ -91,8 +91,8 @@ public class DatabaseAuditWriter implements AuditWriter {
     private void prepareSqlInsertQueries() {
         insertAuditLog = "INSERT INTO " +
                 tableNameAudit +
-                "(audit_log_id, application_name, audit_level, timestamp_created, message, exception_message, stack_trace, param, calling_class, thread_name, version, build_time) " +
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+                "(audit_log_id, application_name, audit_level, audit_type, timestamp_created, message, exception_message, stack_trace, param, calling_class, thread_name, version, build_time) " +
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
         insertAuditParam = "INSERT INTO " +
                 tableNameParam +
                 "(audit_log_id, timestamp_created, param_key, param_value) " +
@@ -137,24 +137,25 @@ public class DatabaseAuditWriter implements AuditWriter {
                                     ps.setString(1, record.getId());
                                     ps.setString(2, applicationName);
                                     ps.setString(3, record.getLevel().toString());
-                                    ps.setTimestamp(4, new Timestamp(record.getTimestamp().getTime()));
-                                    ps.setString(5, record.getMessage());
+                                    ps.setString(4, record.getType());
+                                    ps.setTimestamp(5, new Timestamp(record.getTimestamp().getTime()));
+                                    ps.setString(6, record.getMessage());
                                     Throwable throwable = record.getThrowable();
                                     if (throwable == null) {
-                                        ps.setNull(6, Types.VARCHAR);
                                         ps.setNull(7, Types.VARCHAR);
+                                        ps.setNull(8, Types.VARCHAR);
                                     } else {
                                         StringWriter sw = new StringWriter();
                                         PrintWriter pw = new PrintWriter(sw);
                                         throwable.printStackTrace(pw);
-                                        ps.setString(6, throwable.getMessage());
-                                        ps.setString(7, sw.toString());
+                                        ps.setString(7, throwable.getMessage());
+                                        ps.setString(8, sw.toString());
                                     }
-                                    ps.setString(8, jsonUtil.serializeMap(record.getParam()));
-                                    ps.setString(9, record.getCallingClass().getName());
-                                    ps.setString(10, record.getThreadName());
-                                    ps.setString(11, version);
-                                    ps.setTimestamp(12, new Timestamp(buildTime.toEpochMilli()));
+                                    ps.setString(9, jsonUtil.serializeMap(record.getParam()));
+                                    ps.setString(10, record.getCallingClass().getName());
+                                    ps.setString(11, record.getThreadName());
+                                    ps.setString(12, version);
+                                    ps.setTimestamp(13, new Timestamp(buildTime.toEpochMilli()));
                                 }
 
                                 public int getBatchSize() {

--- a/audit-base/src/main/java/com/wultra/core/audit/base/model/AuditDetail.java
+++ b/audit-base/src/main/java/com/wultra/core/audit/base/model/AuditDetail.java
@@ -28,53 +28,104 @@ public class AuditDetail {
     private String type;
     private final Map<String, Object> param = new LinkedHashMap<>();
 
+    /**
+     * Default constructor.
+     */
     public AuditDetail() {
     }
 
+    /**
+     * Constructor with audit type.
+     * @param type Audit type.
+     */
     public AuditDetail(String type) {
         this.type = type;
     }
 
+    /**
+     * Constuctor with audit type and parameters.
+     * @param type Audit type.
+     * @param param Audit parameters.
+     */
     public AuditDetail(String type, Map<String, Object> param) {
         this.type = type;
         this.param.putAll(param);
     }
 
+    /**
+     * Get audit type.
+     * @return Audit type.
+     */
     public String getType() {
         return type;
     }
 
+    /**
+     * Set audit type.
+     * @param type Audit type.
+     */
     public void setType(String type) {
         this.type = type;
     }
 
+    /**
+     * Get audit parameters.
+     * @return Audit parameters.
+     */
     public Map<String, Object> getParam() {
         return param;
     }
 
+    /**
+     * Get audit detail builder.
+     * @return Audit detail builder.
+     */
     public static Builder builder() {
         return new Builder();
     }
 
+    /**
+     * Audit detail builder.
+     */
     public static class Builder {
 
         private final AuditDetail auditDetail = new AuditDetail();
 
+        /**
+         * Set audit type.
+         * @param type Audit type.
+         * @return Audit detail builder.
+         */
         public Builder type(String type) {
             auditDetail.setType(type);
             return this;
         }
 
+        /**
+         * Set audit parameter.
+         * @param key Parameter key.
+         * @param value Parameter value.
+         * @return Audit detail builder.
+         */
         public Builder param(String key, Object value) {
             auditDetail.getParam().put(key, value);
             return this;
         }
 
+        /**
+         * Set audit parameters.
+         * @param params Audit parameters.
+         * @return Audit detail builder.
+         */
         public Builder params(Map<String, Object> params) {
             auditDetail.getParam().putAll(params);
             return this;
         }
 
+        /**
+         * Build the audit detail.
+         * @return Audit detail.
+         */
         public AuditDetail build() {
             return auditDetail;
         }

--- a/audit-base/src/main/java/com/wultra/core/audit/base/model/AuditDetail.java
+++ b/audit-base/src/main/java/com/wultra/core/audit/base/model/AuditDetail.java
@@ -43,7 +43,15 @@ public class AuditDetail {
     }
 
     /**
-     * Constuctor with audit type and parameters.
+     * Constructor with audit parameters.
+     * @param param Audit parameters.
+     */
+    public AuditDetail(Map<String, Object> param) {
+        this.param.putAll(param);
+    }
+
+    /**
+     * Constructor with audit type and parameters.
      * @param type Audit type.
      * @param param Audit parameters.
      */

--- a/audit-base/src/main/java/com/wultra/core/audit/base/model/AuditDetail.java
+++ b/audit-base/src/main/java/com/wultra/core/audit/base/model/AuditDetail.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2021 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.wultra.core.audit.base.model;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Detailed audit information.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public class AuditDetail {
+
+    private String type;
+    private final Map<String, Object> param = new LinkedHashMap<>();
+
+    public AuditDetail() {
+    }
+
+    public AuditDetail(String type) {
+        this.type = type;
+    }
+
+    public AuditDetail(String type, Map<String, Object> param) {
+        this.type = type;
+        this.param.putAll(param);
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public Map<String, Object> getParam() {
+        return param;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private final AuditDetail auditDetail = new AuditDetail();
+
+        public Builder type(String type) {
+            auditDetail.setType(type);
+            return this;
+        }
+
+        public Builder param(String key, Object value) {
+            auditDetail.getParam().put(key, value);
+            return this;
+        }
+
+        public Builder params(Map<String, Object> params) {
+            auditDetail.getParam().putAll(params);
+            return this;
+        }
+
+        public AuditDetail build() {
+            return auditDetail;
+        }
+
+    }
+}

--- a/audit-base/src/main/java/com/wultra/core/audit/base/model/AuditParam.java
+++ b/audit-base/src/main/java/com/wultra/core/audit/base/model/AuditParam.java
@@ -46,18 +46,34 @@ public class AuditParam {
         this.value = value;
     }
 
+    /**
+     * Get audit log identifier.
+     * @return Audit log identifier.
+     */
     public String getAuditLogId() {
         return auditLogId;
     }
 
+    /**
+     * Get audit timestamp.
+     * @return Audit timestamp.
+     */
     public Date getTimestamp() {
         return timestamp;
     }
 
+    /**
+     * Get parameter key.
+     * @return Parameter key.
+     */
     public String getKey() {
         return key;
     }
 
+    /**
+     * Get parameter value.
+     * @return Parameter value.
+     */
     public Object getValue() {
         return value;
     }

--- a/audit-base/src/main/java/com/wultra/core/audit/base/model/AuditRecord.java
+++ b/audit-base/src/main/java/com/wultra/core/audit/base/model/AuditRecord.java
@@ -34,6 +34,7 @@ public class AuditRecord {
     private final String id;
     private final Date timestamp;
     private final AuditLevel level;
+    private final String type;
     private final Map<String, Object> param;
     private String message;
     private Throwable throwable;
@@ -44,13 +45,15 @@ public class AuditRecord {
      * Audit record constructor.
      * @param message Audit message or message pattern in case message arguments are present.
      * @param level Audit level.
+     * @param type Audit type.
      * @param param Audit parameters.
      * @param args Message arguments.
      */
-    public AuditRecord(@NonNull String message, @NonNull AuditLevel level, @NonNull Map<String, Object> param, Object[] args) {
+    public AuditRecord(@NonNull String message, @NonNull AuditLevel level, String type, @NonNull Map<String, Object> param, Object[] args) {
         this.id = UUID.randomUUID().toString();
         this.timestamp = new Date();
         this.level = level;
+        this.type = type;
         this.param = param;
         if (args != null) {
             parseArgs(message, args);
@@ -95,6 +98,14 @@ public class AuditRecord {
      */
     public AuditLevel getLevel() {
         return level;
+    }
+
+    /**
+     * Get audit type.
+     * @return Audit type.
+     */
+    public String getType() {
+        return type;
     }
 
     /**
@@ -161,11 +172,16 @@ public class AuditRecord {
     @Override
     public String toString() {
         return "AuditRecord{" +
-                "timestamp=" + timestamp +
-                ", message='" + message + '\'' +
+                "id='" + id + '\'' +
+                ", timestamp=" + timestamp +
                 ", level=" + level +
-                ", throwable=" + throwable +
+                ", type='" + type + '\'' +
                 ", param=" + param +
+                ", message='" + message + '\'' +
+                ", throwable=" + throwable +
+                ", callingClass=" + callingClass +
+                ", threadName='" + threadName + '\'' +
                 '}';
     }
+
 }

--- a/audit-base/src/main/java/com/wultra/core/audit/base/util/ClassUtil.java
+++ b/audit-base/src/main/java/com/wultra/core/audit/base/util/ClassUtil.java
@@ -40,13 +40,4 @@ public class ClassUtil extends SecurityManager {
         return trace[trace.length - 1];
     }
 
-    private static final class ClassContextSecurityManager extends SecurityManager {
-        private ClassContextSecurityManager() {
-        }
-
-        protected Class<?>[] getClassContext() {
-            return super.getClassContext();
-        }
-    }
-
 }

--- a/audit-base/src/test/resources/db_schema.sql
+++ b/audit-base/src/test/resources/db_schema.sql
@@ -30,7 +30,7 @@ CREATE TABLE audit_param (
     audit_log_id       VARCHAR(36),
     timestamp_created  TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     param_key          VARCHAR(256),
-    param_value        VARCHAR(3072)
+    param_value        VARCHAR(4000)
 );
 
 --

--- a/audit-base/src/test/resources/db_schema.sql
+++ b/audit-base/src/test/resources/db_schema.sql
@@ -11,6 +11,7 @@ CREATE TABLE audit_log (
     audit_log_id       VARCHAR(36) PRIMARY KEY,
     application_name   VARCHAR(256) NOT NULL,
     audit_level        VARCHAR(32) NOT NULL,
+    audit_type         VARCHAR(256),
     timestamp_created  TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     message            TEXT NOT NULL,
     exception_message  TEXT,
@@ -38,6 +39,7 @@ CREATE TABLE audit_param (
 CREATE INDEX audit_log_timestamp ON audit_log (timestamp_created);
 CREATE INDEX audit_log_application ON audit_log (application_name);
 CREATE INDEX audit_log_level ON audit_log (audit_level);
+CREATE INDEX audit_log_type ON audit_log (audit_type);
 CREATE INDEX audit_param_log ON audit_param (audit_log_id);
 CREATE INDEX audit_param_timestamp ON audit_param (timestamp_created);
 CREATE INDEX audit_param_key ON audit_param (param_key);

--- a/docs/sql/mysql/create_schema.sql
+++ b/docs/sql/mysql/create_schema.sql
@@ -37,4 +37,4 @@ CREATE INDEX audit_log_type ON audit_log (audit_type);
 CREATE INDEX audit_param_log ON audit_param (audit_log_id);
 CREATE INDEX audit_param_timestamp ON audit_param (timestamp_created);
 CREATE INDEX audit_param_key ON audit_param (param_key);
-CREATE INDEX audit_param_value ON audit_param (param_value);
+CREATE FULLTEXT INDEX audit_param_value ON audit_param (param_value);

--- a/docs/sql/mysql/create_schema.sql
+++ b/docs/sql/mysql/create_schema.sql
@@ -5,6 +5,7 @@ CREATE TABLE audit_log (
     audit_log_id       VARCHAR(36) PRIMARY KEY,
     application_name   VARCHAR(256) NOT NULL,
     audit_level        VARCHAR(32) NOT NULL,
+    audit_type         VARCHAR(256),
     timestamp_created  TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     message            TEXT NOT NULL,
     exception_message  TEXT,
@@ -32,6 +33,7 @@ CREATE TABLE audit_param (
 CREATE INDEX audit_log_timestamp ON audit_log (timestamp_created);
 CREATE INDEX audit_log_application ON audit_log (application_name);
 CREATE INDEX audit_log_level ON audit_log (audit_level);
+CREATE INDEX audit_log_type ON audit_log (audit_type);
 CREATE INDEX audit_param_log ON audit_param (audit_log_id);
 CREATE INDEX audit_param_timestamp ON audit_param (timestamp_created);
 CREATE INDEX audit_param_key ON audit_param (param_key);

--- a/docs/sql/oracle/create_schema.sql
+++ b/docs/sql/oracle/create_schema.sql
@@ -24,7 +24,7 @@ CREATE TABLE audit_param (
     audit_log_id       VARCHAR2(36 CHAR),
     timestamp_created  TIMESTAMP,
     param_key          VARCHAR2(256 CHAR),
-    param_value        VARCHAR2(3072 CHAR)
+    param_value        VARCHAR2(4000 CHAR)
 );
 
 --

--- a/docs/sql/oracle/create_schema.sql
+++ b/docs/sql/oracle/create_schema.sql
@@ -5,6 +5,7 @@ CREATE TABLE audit_log (
     audit_log_id       VARCHAR2(36 CHAR) PRIMARY KEY,
     application_name   VARCHAR2(256 CHAR) NOT NULL,
     audit_level        VARCHAR2(32 CHAR) NOT NULL,
+    audit_type         VARCHAR2(256 CHAR),
     timestamp_created  TIMESTAMP,
     message            CLOB NOT NULL,
     exception_message  CLOB,
@@ -32,6 +33,7 @@ CREATE TABLE audit_param (
 CREATE INDEX audit_log_timestamp ON audit_log (timestamp_created);
 CREATE INDEX audit_log_application ON audit_log (application_name);
 CREATE INDEX audit_log_level ON audit_log (audit_level);
+CREATE INDEX audit_log_type ON audit_log (audit_type);
 CREATE INDEX audit_param_log ON audit_param (audit_log_id);
 CREATE INDEX audit_param_timestamp ON audit_param (timestamp_created);
 CREATE INDEX audit_param_key ON audit_param (param_key);

--- a/docs/sql/postgresql/create_schema.sql
+++ b/docs/sql/postgresql/create_schema.sql
@@ -24,7 +24,7 @@ CREATE TABLE audit_param (
     audit_log_id       VARCHAR(36),
     timestamp_created  TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     param_key          VARCHAR(256),
-    param_value        VARCHAR(3072)
+    param_value        VARCHAR(4000)
 );
 
 --

--- a/docs/sql/postgresql/create_schema.sql
+++ b/docs/sql/postgresql/create_schema.sql
@@ -5,6 +5,7 @@ CREATE TABLE audit_log (
     audit_log_id       VARCHAR(36) PRIMARY KEY,
     application_name   VARCHAR(256) NOT NULL,
     audit_level        VARCHAR(32) NOT NULL,
+    audit_type         VARCHAR(256),
     timestamp_created  TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     message            TEXT NOT NULL,
     exception_message  TEXT,
@@ -32,6 +33,7 @@ CREATE TABLE audit_param (
 CREATE INDEX audit_log_timestamp ON audit_log (timestamp_created);
 CREATE INDEX audit_log_application ON audit_log (application_name);
 CREATE INDEX audit_log_level ON audit_log (audit_level);
+CREATE INDEX audit_log_type ON audit_log (audit_type);
 CREATE INDEX audit_param_log ON audit_param (audit_log_id);
 CREATE INDEX audit_param_timestamp ON audit_param (timestamp_created);
 CREATE INDEX audit_param_key ON audit_param (param_key);


### PR DESCRIPTION
I added the `AuditDetail` which contains the audit type, it looks quite ok from my point of view. For basic auditing the interface is still simple and for details these can be easily constructed and/or stored for repeated usage. The current approach is also easily extensible with new audit details and columns.