### PR TITLE
Fix #58: Consider switching to pgp-maven-plugin for artifact signing

### DIFF
--- a/audit-base/pom.xml
+++ b/audit-base/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>io.getlime.core</groupId>
         <artifactId>lime-java-core-parent</artifactId>
-        <version>1.3.0</version>
+        <version>1.4.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>audit-base</artifactId>
-    <version>1.3.0</version>
+    <version>1.4.0-SNAPSHOT</version>
     <name>audit-base</name>
     <description>Common auditing functionality used by Wultra backend Java projects</description>
     <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,7 @@
 					<plugin>
 						<groupId>org.kohsuke</groupId>
 						<artifactId>pgp-maven-plugin</artifactId>
+						<version>1.1</version>
 						<executions>
 							<execution>
 								<goals>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<description>Wultra - Core Java Libraries</description>
 	<groupId>io.getlime.core</groupId>
 	<artifactId>lime-java-core-parent</artifactId>
-	<version>1.3.0</version>
+	<version>1.4.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<inceptionYear>2017</inceptionYear>
@@ -106,13 +106,10 @@
 			<build>
 				<plugins>
 					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-gpg-plugin</artifactId>
-						<version>3.0.1</version>
+						<groupId>org.kohsuke</groupId>
+						<artifactId>pgp-maven-plugin</artifactId>
 						<executions>
 							<execution>
-								<id>sign-artifacts</id>
-								<phase>verify</phase>
 								<goals>
 									<goal>sign</goal>
 								</goals>

--- a/rest-client-base/pom.xml
+++ b/rest-client-base/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>io.getlime.core</groupId>
         <artifactId>lime-java-core-parent</artifactId>
-        <version>1.3.0</version>
+        <version>1.4.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>rest-client-base</artifactId>
-    <version>1.3.0</version>
+    <version>1.4.0-SNAPSHOT</version>
     <name>rest-client-base</name>
     <description>Default implementation of REST client</description>
     <packaging>jar</packaging>
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>io.getlime.core</groupId>
             <artifactId>rest-model-base</artifactId>
-            <version>1.3.0</version>
+            <version>1.4.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/rest-model-base/pom.xml
+++ b/rest-model-base/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<groupId>io.getlime.core</groupId>
 		<artifactId>lime-java-core-parent</artifactId>
-		<version>1.3.0</version>
+		<version>1.4.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>rest-model-base</artifactId>
-	<version>1.3.0</version>
+	<version>1.4.0-SNAPSHOT</version>
 	<name>rest-model-base</name>
 	<description>Model classes for Wultra back-end Java projects</description>
 	<packaging>jar</packaging>


### PR DESCRIPTION
I successfully signed a snapshot build using a Jenkins job and the pgp-maven-plugin:
https://oss.sonatype.org/content/repositories/snapshots/io/getlime/core/rest-client-base/1.4.0-SNAPSHOT/

The downside is that the plug-in only supports RSA keys. Let's consider whether we can live with this limitation, otherwise the signing works fine:
```
gpg --verify rest-client-base-1.4.0-20210824.091753-1-javadoc.jar.asc rest-client-base-1.4.0-20210824.091753-1-javadoc.jar
...
gpg:                using RSA key 90AF34C2729A5F5B
gpg: Good signature from "Petr Dvorak <hello@wultra.com>" [ultimate]
```