### PR TITLE
Refactor RestClientConfiguration and DefaultRestClientTest

### DIFF
--- a/rest-client-base/src/main/java/com/wultra/core/rest/client/base/RestClientConfiguration.java
+++ b/rest-client-base/src/main/java/com/wultra/core/rest/client/base/RestClientConfiguration.java
@@ -21,7 +21,6 @@ import org.springframework.http.MediaType;
 import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
 
 import java.time.Duration;
-import java.util.Optional;
 
 /**
  * REST client configuration.
@@ -29,12 +28,6 @@ import java.util.Optional;
  * @author Roman Strobl, roman.strobl@wultra.com
  */
 public class RestClientConfiguration {
-
-    /**
-     * Constructor of REST client configuration.
-     */
-    public RestClientConfiguration() {
-    }
 
     // Basic settings
     private String baseUrl;

--- a/rest-client-base/src/test/java/com/wultra/core/rest/client/base/DefaultRestClientTest.java
+++ b/rest-client-base/src/test/java/com/wultra/core/rest/client/base/DefaultRestClientTest.java
@@ -54,7 +54,7 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-public class DefaultRestClientTest {
+class DefaultRestClientTest {
 
     @LocalServerPort
     private int port;
@@ -65,7 +65,7 @@ public class DefaultRestClientTest {
     private static final int SYNCHRONIZATION_TIMEOUT = 10000;
 
     @BeforeEach
-    public void initRestClient() throws RestClientException {
+    void initRestClient() throws RestClientException {
         RestClientConfiguration config = prepareConfiguration();
         config.setBaseUrl("https://localhost:" + port + "/api/test");
         restClient = new DefaultRestClient(config);
@@ -91,21 +91,21 @@ public class DefaultRestClientTest {
     }
 
     @Test
-    public void testGetWithResponse() throws RestClientException {
+    void testGetWithResponse() throws RestClientException {
         ResponseEntity<Response> responseEntity = restClient.get("/response", new ParameterizedTypeReference<Response>() {});
         assertNotNull(responseEntity.getBody());
         assertEquals("OK", responseEntity.getBody().getStatus());
     }
 
     @Test
-    public void testGetWithResponseObject() throws RestClientException {
+    void testGetWithResponseObject() throws RestClientException {
         Response response = restClient.getObject("/response");
         assertNotNull(response);
         assertEquals("OK", response.getStatus());
     }
 
     @Test
-    public void testGetWithResponseNonBlocking() throws RestClientException, InterruptedException {
+    void testGetWithResponseNonBlocking() throws RestClientException, InterruptedException {
         CountDownLatch countDownLatch = new CountDownLatch(1);
         Consumer<ResponseEntity<Response>> onSuccess = responseEntity -> {
             assertNotNull(responseEntity);
@@ -119,14 +119,14 @@ public class DefaultRestClientTest {
     }
 
     @Test
-    public void testGetWithTestResponse() throws RestClientException {
+    void testGetWithTestResponse() throws RestClientException {
         ResponseEntity<TestResponse> responseEntity = restClient.get("/test-response", new ParameterizedTypeReference<TestResponse>() {});
         assertNotNull(responseEntity.getBody());
         assertEquals("test response", responseEntity.getBody().getResponse());
     }
 
     @Test
-    public void testGetWithObjectResponse() throws RestClientException {
+    void testGetWithObjectResponse() throws RestClientException {
         ResponseEntity<ObjectResponse<TestResponse>> responseEntity = restClient.get("/object-response", new ParameterizedTypeReference<ObjectResponse<TestResponse>>() {});
         assertNotNull(responseEntity.getBody());
         assertEquals("OK", responseEntity.getBody().getStatus());
@@ -134,28 +134,28 @@ public class DefaultRestClientTest {
     }
 
     @Test
-    public void testGetWithObjectResponseObject() throws RestClientException {
+    void testGetWithObjectResponseObject() throws RestClientException {
         ObjectResponse<TestResponse> response = restClient.getObject("/object-response", TestResponse.class);
         assertNotNull(response.getResponseObject());
         assertEquals("object response", response.getResponseObject().getResponse());
     }
 
     @Test
-    public void testPostWithResponse() throws RestClientException {
+    void testPostWithResponse() throws RestClientException {
         ResponseEntity<Response> responseEntity = restClient.post("/response", null, new ParameterizedTypeReference<Response>() {});
         assertNotNull(responseEntity.getBody());
         assertEquals("OK", responseEntity.getBody().getStatus());
     }
 
     @Test
-    public void testPostWithResponseObject() throws RestClientException {
+    void testPostWithResponseObject() throws RestClientException {
         Response response = restClient.postObject("/response", null);
         assertNotNull(response);
         assertEquals("OK", response.getStatus());
     }
 
     @Test
-    public void testPostWithResponseNonBlocking() throws RestClientException, InterruptedException {
+    void testPostWithResponseNonBlocking() throws RestClientException, InterruptedException {
         CountDownLatch countDownLatch = new CountDownLatch(1);
         Consumer<ResponseEntity<Response>> onSuccess = responseEntity -> {
             assertNotNull(responseEntity);
@@ -169,14 +169,14 @@ public class DefaultRestClientTest {
     }
 
     @Test
-    public void testPostWithTestResponse() throws RestClientException {
+    void testPostWithTestResponse() throws RestClientException {
         ResponseEntity<TestResponse> responseEntity = restClient.post("/test-response", null, new ParameterizedTypeReference<TestResponse>() {});
         assertNotNull(responseEntity.getBody());
         assertEquals("test response", responseEntity.getBody().getResponse());
     }
 
     @Test
-    public void testPostWithObjectResponse() throws RestClientException {
+    void testPostWithObjectResponse() throws RestClientException {
         ResponseEntity<ObjectResponse<TestResponse>> responseEntity = restClient.post("/object-response", null, new ParameterizedTypeReference<ObjectResponse<TestResponse>>() {});
         assertNotNull(responseEntity.getBody());
         assertEquals("OK", responseEntity.getBody().getStatus());
@@ -184,14 +184,14 @@ public class DefaultRestClientTest {
     }
 
     @Test
-    public void testPostWithObjectResponseObject() throws RestClientException {
+    void testPostWithObjectResponseObject() throws RestClientException {
         ObjectResponse<TestResponse> response = restClient.postObject("/object-response", null, TestResponse.class);
         assertNotNull(response.getResponseObject());
         assertEquals("object response", response.getResponseObject().getResponse());
     }
 
     @Test
-    public void testPostWithObjectRequestResponse() throws RestClientException {
+    void testPostWithObjectRequestResponse() throws RestClientException {
         String requestData = String.valueOf(System.currentTimeMillis());
         ObjectRequest<TestRequest> request = new ObjectRequest<>(new TestRequest(requestData));
         ResponseEntity<ObjectResponse<TestResponse>> responseEntity = restClient.post("/object-request-response", request, new ParameterizedTypeReference<ObjectResponse<TestResponse>>(){});
@@ -203,7 +203,7 @@ public class DefaultRestClientTest {
     }
 
     @Test
-    public void testPostWithObjectRequestResponseObject() throws RestClientException {
+    void testPostWithObjectRequestResponseObject() throws RestClientException {
         String requestData = String.valueOf(System.currentTimeMillis());
         ObjectRequest<TestRequest> request = new ObjectRequest<>(new TestRequest(requestData));
         ObjectResponse<TestResponse> response = restClient.postObject("/object-request-response", request, TestResponse.class);
@@ -212,7 +212,7 @@ public class DefaultRestClientTest {
     }
 
     @Test
-    public void testPostWithObjectRequestResponseNonBlocking() throws RestClientException, InterruptedException {
+    void testPostWithObjectRequestResponseNonBlocking() throws RestClientException, InterruptedException {
         CountDownLatch countDownLatch = new CountDownLatch(1);
         String requestData = String.valueOf(System.currentTimeMillis());
         ObjectRequest<TestRequest> request = new ObjectRequest<>(new TestRequest(requestData));
@@ -229,21 +229,21 @@ public class DefaultRestClientTest {
     }
 
     @Test
-    public void testPutWithResponse() throws RestClientException {
+    void testPutWithResponse() throws RestClientException {
         ResponseEntity<Response> responseEntity = restClient.put("/response", null, new ParameterizedTypeReference<Response>() {});
         assertNotNull(responseEntity.getBody());
         assertEquals("OK", responseEntity.getBody().getStatus());
     }
 
     @Test
-    public void testPutWithResponseObject() throws RestClientException {
+    void testPutWithResponseObject() throws RestClientException {
         Response response = restClient.putObject("/response", null);
         assertNotNull(response);
         assertEquals("OK", response.getStatus());
     }
 
     @Test
-    public void testPutWithResponseNonBlocking() throws RestClientException, InterruptedException {
+    void testPutWithResponseNonBlocking() throws RestClientException, InterruptedException {
         CountDownLatch countDownLatch = new CountDownLatch(1);
         Consumer<ResponseEntity<Response>> onSuccess = responseEntity -> {
             assertNotNull(responseEntity);
@@ -257,14 +257,14 @@ public class DefaultRestClientTest {
     }
 
     @Test
-    public void testPutWithTestResponse() throws RestClientException {
+    void testPutWithTestResponse() throws RestClientException {
         ResponseEntity<TestResponse> responseEntity = restClient.put("/test-response", null, new ParameterizedTypeReference<TestResponse>() {});
         assertNotNull(responseEntity.getBody());
         assertEquals("test response", responseEntity.getBody().getResponse());
     }
 
     @Test
-    public void testPutWithObjectResponse() throws RestClientException {
+    void testPutWithObjectResponse() throws RestClientException {
         ResponseEntity<ObjectResponse<TestResponse>> responseEntity = restClient.put("/object-response", null, new ParameterizedTypeReference<ObjectResponse<TestResponse>>() {});
         assertNotNull(responseEntity.getBody());
         assertEquals("OK", responseEntity.getBody().getStatus());
@@ -272,14 +272,14 @@ public class DefaultRestClientTest {
     }
 
     @Test
-    public void testPutWithObjectResponseObject() throws RestClientException {
+    void testPutWithObjectResponseObject() throws RestClientException {
         ObjectResponse<TestResponse> response = restClient.putObject("/object-response", null, TestResponse.class);
         assertNotNull(response.getResponseObject());
         assertEquals("object response", response.getResponseObject().getResponse());
     }
 
     @Test
-    public void testPutWithObjectRequestResponse() throws RestClientException {
+    void testPutWithObjectRequestResponse() throws RestClientException {
         String requestData = String.valueOf(System.currentTimeMillis());
         ObjectRequest<TestRequest> request = new ObjectRequest<>(new TestRequest(requestData));
         ResponseEntity<ObjectResponse<TestResponse>> responseEntity = restClient.put("/object-request-response", request, new ParameterizedTypeReference<ObjectResponse<TestResponse>>(){});
@@ -291,7 +291,7 @@ public class DefaultRestClientTest {
     }
 
     @Test
-    public void testPutWithObjectRequestResponseObject() throws RestClientException {
+    void testPutWithObjectRequestResponseObject() throws RestClientException {
         String requestData = String.valueOf(System.currentTimeMillis());
         ObjectRequest<TestRequest> request = new ObjectRequest<>(new TestRequest(requestData));
         ObjectResponse<TestResponse> response = restClient.putObject("/object-request-response", request, TestResponse.class);
@@ -300,7 +300,7 @@ public class DefaultRestClientTest {
     }
 
     @Test
-    public void testPutWithObjectRequestResponseNonBlocking() throws RestClientException, InterruptedException {
+    void testPutWithObjectRequestResponseNonBlocking() throws RestClientException, InterruptedException {
         CountDownLatch countDownLatch = new CountDownLatch(1);
         String requestData = String.valueOf(System.currentTimeMillis());
         ObjectRequest<TestRequest> request = new ObjectRequest<>(new TestRequest(requestData));
@@ -317,21 +317,21 @@ public class DefaultRestClientTest {
     }
 
     @Test
-    public void testDeleteWithResponse() throws RestClientException {
+    void testDeleteWithResponse() throws RestClientException {
         ResponseEntity<Response> responseEntity = restClient.delete("/response", new ParameterizedTypeReference<Response>() {});
         assertNotNull(responseEntity.getBody());
         assertEquals("OK", responseEntity.getBody().getStatus());
     }
 
     @Test
-    public void testDeleteWithResponseObject() throws RestClientException {
+    void testDeleteWithResponseObject() throws RestClientException {
         Response response = restClient.deleteObject("/response");
         assertNotNull(response);
         assertEquals("OK", response.getStatus());
     }
 
     @Test
-    public void testDeleteWithResponseNonBlocking() throws RestClientException, InterruptedException {
+    void testDeleteWithResponseNonBlocking() throws RestClientException, InterruptedException {
         CountDownLatch countDownLatch = new CountDownLatch(1);
         Consumer<ResponseEntity<Response>> onSuccess = responseEntity -> {
             assertNotNull(responseEntity);
@@ -345,14 +345,14 @@ public class DefaultRestClientTest {
     }
 
     @Test
-    public void testDeleteWithTestResponse() throws RestClientException {
+    void testDeleteWithTestResponse() throws RestClientException {
         ResponseEntity<TestResponse> responseEntity = restClient.delete("/test-response", new ParameterizedTypeReference<TestResponse>() {});
         assertNotNull(responseEntity.getBody());
         assertEquals("test response", responseEntity.getBody().getResponse());
     }
 
     @Test
-    public void testDeleteWithObjectResponse() throws RestClientException {
+    void testDeleteWithObjectResponse() throws RestClientException {
         ResponseEntity<ObjectResponse<TestResponse>> responseEntity = restClient.delete("/object-response", new ParameterizedTypeReference<ObjectResponse<TestResponse>>() {});
         assertNotNull(responseEntity.getBody());
         assertEquals("OK", responseEntity.getBody().getStatus());
@@ -360,14 +360,14 @@ public class DefaultRestClientTest {
     }
 
     @Test
-    public void testDeleteWithObjectResponseObject() throws RestClientException {
+    void testDeleteWithObjectResponseObject() throws RestClientException {
         ObjectResponse<TestResponse> response = restClient.deleteObject("/object-response", TestResponse.class);
         assertNotNull(response.getResponseObject());
         assertEquals("object response", response.getResponseObject().getResponse());
     }
 
     @Test
-    public void testPostWithErrorResponse() {
+    void testPostWithErrorResponse() {
         try {
             restClient.post("/error-response", null, new ParameterizedTypeReference<ObjectResponse<TestResponse>>() {});
         } catch (RestClientException ex) {
@@ -381,7 +381,7 @@ public class DefaultRestClientTest {
     }
 
     @Test
-    public void testPostWithErrorResponseObject() {
+    void testPostWithErrorResponseObject() {
         try {
             restClient.postObject("/error-response", null, TestResponse.class);
         } catch (RestClientException ex) {
@@ -395,7 +395,7 @@ public class DefaultRestClientTest {
     }
 
     @Test
-    public void testPostWithErrorResponseNonBlocking() throws RestClientException, InterruptedException {
+    void testPostWithErrorResponseNonBlocking() throws RestClientException, InterruptedException {
         CountDownLatch countDownLatch = new CountDownLatch(1);
         Consumer<ResponseEntity<ObjectResponse<TestResponse>>> onSuccess = okResponse -> Assertions.fail();
         Consumer<Throwable> onError = error -> {
@@ -413,7 +413,7 @@ public class DefaultRestClientTest {
     }
 
     @Test
-    public void testGetWithFullUrl() throws RestClientException {
+    void testGetWithFullUrl() throws RestClientException {
         RestClientConfiguration config = prepareConfiguration();
         restClient = new DefaultRestClient(config);
         Response response = restClient.getObject("https://localhost:" + port + "/api/test/response");
@@ -422,7 +422,7 @@ public class DefaultRestClientTest {
     }
 
     @Test
-    public void testPostWithFullUrl() throws RestClientException {
+    void testPostWithFullUrl() throws RestClientException {
         RestClientConfiguration config = prepareConfiguration();
         restClient = new DefaultRestClient(config);
         Response response = restClient.postObject("https://localhost:" + port + "/api/test/response", null);
@@ -431,7 +431,7 @@ public class DefaultRestClientTest {
     }
 
     @Test
-    public void testPutWithFullUrl() throws RestClientException {
+    void testPutWithFullUrl() throws RestClientException {
         RestClientConfiguration config = prepareConfiguration();
         restClient = new DefaultRestClient(config);
         Response response = restClient.putObject("https://localhost:" + port + "/api/test/response", null);
@@ -440,7 +440,7 @@ public class DefaultRestClientTest {
     }
 
     @Test
-    public void testDeleteWithFullUrl() throws RestClientException {
+    void testDeleteWithFullUrl() throws RestClientException {
         RestClientConfiguration config = prepareConfiguration();
         restClient = new DefaultRestClient(config);
         Response response = restClient.deleteObject("https://localhost:" + port + "/api/test/response");
@@ -449,7 +449,7 @@ public class DefaultRestClientTest {
     }
 
     @Test
-    public void testPostWithDataBuffer() throws RestClientException, JsonProcessingException {
+    void testPostWithDataBuffer() throws RestClientException, JsonProcessingException {
         String requestData = String.valueOf(System.currentTimeMillis());
         ObjectRequest<TestRequest> request = new ObjectRequest<>(new TestRequest(requestData));
         ObjectMapper objectMapper = new ObjectMapper();
@@ -466,7 +466,7 @@ public class DefaultRestClientTest {
     }
 
     @Test
-    public void testPostWithMultipartData() throws RestClientException {
+    void testPostWithMultipartData() throws RestClientException {
         String requestData = String.valueOf(System.currentTimeMillis());
         TestRequest testRequest = new TestRequest(requestData);
         MultipartBodyBuilder bodyBuilder = new MultipartBodyBuilder();
@@ -485,7 +485,7 @@ public class DefaultRestClientTest {
     }
 
     @Test
-    public void testDefaultHttpHeaders() throws RestClientException {
+    void testDefaultHttpHeaders() throws RestClientException {
         String headerName = "Header-Name";
         String headerVaue = "value";
         HttpHeaders headers = new HttpHeaders();
@@ -503,7 +503,7 @@ public class DefaultRestClientTest {
     }
 
     @Test
-    public void testConfiguration() throws RestClientException {
+    void testConfiguration() throws RestClientException {
         final RestClientConfiguration config = prepareConfiguration();
         final DefaultRestClient restClient = new DefaultRestClient(config);
 


### PR DESCRIPTION
- Remove no-arg constructor from `RestClientConfiguration`.
- Remove public from `DefaultRestClientTest`.