### PR TITLE
Resolve #112: Add support for http HEAD method to RestClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,10 @@ Once the rest client is initialized, you can use the following methods. Each met
 - `patch` - a blocking PATCH call with a generic request / response
 - `patchNonBlocking` - a non-blocking PATCH call with a generic request / response with `onSuccess` and `onError` consumers
 - `patchObject` - a blocking PATCH call with `ObjectRequest` / `ObjectResponse`
+- `head` - a blocking PATCH call with a generic request
+- `headNonBlocking` - a non-blocking PATCH call with a generic request with `onSuccess` and `onError` consumers
+- `headObject` - a blocking PATCH call with `ObjectRequest`
+
 - `delete` - a blocking DELETE call with a generic response
 - `deleteNonBlocking` - a non-blocking DELETE call with a generic response with `onSuccess` and `onError` consumers
 - `deleteObject` - a blocking DELETE call with `ObjectResponse`

--- a/README.md
+++ b/README.md
@@ -162,9 +162,9 @@ Once the rest client is initialized, you can use the following methods. Each met
 - `patch` - a blocking PATCH call with a generic request / response
 - `patchNonBlocking` - a non-blocking PATCH call with a generic request / response with `onSuccess` and `onError` consumers
 - `patchObject` - a blocking PATCH call with `ObjectRequest` / `ObjectResponse`
-- `head` - a blocking PATCH call with a generic request
-- `headNonBlocking` - a non-blocking PATCH call with a generic request with `onSuccess` and `onError` consumers
-- `headObject` - a blocking PATCH call with `ObjectRequest`
+- `head` - a blocking HEAD call with a generic request
+- `headNonBlocking` - a non-blocking HEAD call with a generic request with `onSuccess` and `onError` consumers
+- `headObject` - a blocking HEAD call with `ObjectRequest`
 
 - `delete` - a blocking DELETE call with a generic response
 - `deleteNonBlocking` - a non-blocking DELETE call with a generic response with `onSuccess` and `onError` consumers

--- a/rest-client-base/src/main/java/com/wultra/core/rest/client/base/DefaultRestClient.java
+++ b/rest-client-base/src/main/java/com/wultra/core/rest/client/base/DefaultRestClient.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
@@ -532,6 +533,78 @@ public class DefaultRestClient implements RestClient {
         ParameterizedTypeReference<ObjectResponse<T>> typeReference = getTypeReference(responseType);
         ResponseEntity<ObjectResponse<T>> responseEntity = patch(path, objectRequest, queryParams, headers, typeReference);
         return responseEntity.getBody();
+    }
+
+    @Override
+    public <T> ResponseEntity<T> head(String path, ParameterizedTypeReference<T> responseType) throws RestClientException {
+        return head(path, null, null, responseType);
+    }
+
+    @Override
+    public <T> ResponseEntity<T> head(String path, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> headers, ParameterizedTypeReference<T> responseType) throws RestClientException {
+        try {
+            return buildUri(webClient.head(), path, queryParams)
+                    .headers(h -> {
+                        if (headers != null) {
+                            h.addAll(headers);
+                        }
+                    })
+                    .exchangeToMono(rs -> handleResponse(rs, responseType))
+                    .defaultIfEmpty(new ResponseEntity<>(HttpStatus.ACCEPTED))
+                    .block();
+        } catch (Exception ex) {
+            if (ex.getCause() instanceof RestClientException) {
+                // Throw exceptions created by REST client
+                throw (RestClientException) ex.getCause();
+            }
+            throw new RestClientException("HTTP HEAD request failed", ex);
+        }
+    }
+
+    @Override
+    public <T> void headNonBlocking(String path, ParameterizedTypeReference<T> responseType, Consumer<ResponseEntity<T>> onSuccess, Consumer<Throwable> onError) throws RestClientException {
+        headNonBlocking(path, null, null, responseType, onSuccess, onError);
+    }
+
+    @Override
+    public <T> void headNonBlocking(String path, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> headers, ParameterizedTypeReference<T> responseType, Consumer<ResponseEntity<T>> onSuccess, Consumer<Throwable> onError) throws RestClientException {
+        try {
+            buildUri(webClient.head(), path, queryParams)
+                    .headers(h -> {
+                        if (headers != null) {
+                            h.addAll(headers);
+                        }
+                    })
+                    .accept(config.getAcceptType())
+                    .exchangeToMono(rs -> handleResponse(rs, responseType))
+                    .subscribe(onSuccess, onError);
+        } catch (Exception ex) {
+            throw new RestClientException("HTTP HEAD request failed", ex);
+        }
+    }
+
+    @Override
+    public Response headObject(String path) throws RestClientException {
+        head(path, new ParameterizedTypeReference<Response>(){});
+        return new Response();
+    }
+
+    @Override
+    public Response headObject(String path, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> headers) throws RestClientException {
+        head(path, queryParams, headers, new ParameterizedTypeReference<Response>(){});
+        return new Response();
+    }
+
+    @Override
+    public <T> ObjectResponse<T> headObject(String path, Class<T> responseType) throws RestClientException {
+        return headObject(path, null, null, responseType);
+    }
+
+    @Override
+    public <T> ObjectResponse<T> headObject(String path, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> headers, Class<T> responseType) throws RestClientException {
+        ParameterizedTypeReference<ObjectResponse<T>> typeReference = getTypeReference(responseType);
+        head(path, queryParams, headers, typeReference);
+        return new ObjectResponse<>();
     }
 
     /**

--- a/rest-client-base/src/main/java/com/wultra/core/rest/client/base/RestClient.java
+++ b/rest-client-base/src/main/java/com/wultra/core/rest/client/base/RestClient.java
@@ -493,4 +493,90 @@ public interface RestClient {
      */
     <T> ObjectResponse<T> patchObject(String path, ObjectRequest<?> objectRequest, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> headers, Class<T> responseType) throws RestClientException;
 
+    /**
+     * Execute a blocking HTTP HEAD request.
+     * @param path Request path.
+     * @param responseType Parameterized response type.
+     * @param <T> Response type.
+     * @return HTTP HEAD response.
+     * @throws RestClientException Thrown in case HTTP HEAD request fails.
+     */
+    <T> ResponseEntity<T> head(String path, ParameterizedTypeReference<T> responseType) throws RestClientException;
+
+    /**
+     * Execute a blocking HTTP HEAD request with specified HTTP headers.
+     * @param path Request path.
+     * @param queryParams Query parameters.
+     * @param headers HTTP headers.
+     * @param responseType Parameterized response type.
+     * @param <T> Response type.
+     * @return HTTP HEAD response.
+     * @throws RestClientException Thrown in case HTTP HEAD request fails.
+     */
+    <T> ResponseEntity<T> head(String path, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> headers, ParameterizedTypeReference<T> responseType) throws RestClientException;
+
+    /**
+     * Execute a non-blocking HTTP HEAD request.
+     * @param path Request path.
+     * @param responseType Parameterized response type.
+     * @param onSuccess Consumer used in case of success.
+     * @param onError Consumer used in case of failure.
+     * @param <T> Response type.
+     * @throws RestClientException Thrown in case HTTP HEAD request fails.
+     */
+    <T> void headNonBlocking(String path, ParameterizedTypeReference<T> responseType, Consumer<ResponseEntity<T>> onSuccess, Consumer<Throwable> onError) throws RestClientException;
+
+    /**
+     * Execute a non-blocking HTTP HEAD request with specified HTTP headers.
+     * @param path Request path.
+     * @param queryParams Query parameters.
+     * @param headers HTTP headers.
+     * @param responseType Parameterized response type.
+     * @param onSuccess Consumer used in case of success.
+     * @param onError Consumer used in case of failure.
+     * @param <T> Response type.
+     * @throws RestClientException Thrown in case HTTP HEAD request fails.
+     */
+    <T> void headNonBlocking(String path, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> headers, ParameterizedTypeReference<T> responseType, Consumer<ResponseEntity<T>> onSuccess, Consumer<Throwable> onError) throws RestClientException;
+
+    /**
+     * Execute a blocking HTTP HEAD request with ObjectRequest / Response types.
+     * @param path Request path.
+     * @return Response.
+     * @throws RestClientException Thrown in case HTTP HEAD request fails.
+     */
+    Response headObject(String path) throws RestClientException;
+
+    /**
+     * Execute a blocking HTTP HEAD request with ObjectRequest / Response types and specified query parameters and HTTP headers.
+     * @param path Request path.
+     * @param queryParams Query parameters.
+     * @param headers HTTP headers.
+     * @return Response.
+     * @throws RestClientException Thrown in case HTTP HEAD request fails.
+     */
+    Response headObject(String path, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> headers) throws RestClientException;
+
+    /**
+     * Execute a blocking HTTP HEAD request with ObjectRequest / ObjectResponse types.
+     * @param path Request path.
+     * @param responseType Object response type.
+     * @param <T> Response type.
+     * @return Object response.
+     * @throws RestClientException Thrown in case HTTP HEAD request fails.
+     */
+    <T> ObjectResponse<T> headObject(String path, Class<T> responseType) throws RestClientException;
+
+    /**
+     * Execute a blocking HTTP HEAD request with ObjectRequest / ObjectResponse types and specified query parameters and HTTP headers.
+     * @param path Request path.
+     * @param queryParams Query parameters.
+     * @param headers HTTP headers.
+     * @param responseType Object response type.
+     * @param <T> Response type.
+     * @return Object response.
+     * @throws RestClientException Thrown in case HTTP HEAD request fails.
+     */
+    <T> ObjectResponse<T> headObject(String path, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> headers, Class<T> responseType) throws RestClientException;
+
 }

--- a/rest-client-base/src/test/java/com/wultra/core/rest/client/base/DefaultRestClientTest.java
+++ b/rest-client-base/src/test/java/com/wultra/core/rest/client/base/DefaultRestClientTest.java
@@ -532,6 +532,67 @@ class DefaultRestClientTest {
     }
 
     @Test
+    void testHeadWithResponse() throws RestClientException {
+        ResponseEntity<Response> responseEntity = restClient.head("/response", new ParameterizedTypeReference<Response>() {});
+        assertFalse(responseEntity.getHeaders().isEmpty());
+        assertNull(responseEntity.getBody());
+    }
+
+    @Test
+    void testHeadWithResponseObject() throws RestClientException {
+        Response response = restClient.headObject("/response");
+        assertNotNull(response);
+        assertEquals("OK", response.getStatus());
+    }
+
+    @Test
+    void testHeadWithResponseNonBlocking() throws RestClientException, InterruptedException {
+        CountDownLatch countDownLatch = new CountDownLatch(1);
+        Consumer<ResponseEntity<Response>> onSuccess = responseEntity -> {
+            assertNotNull(responseEntity);
+            assertNotNull(responseEntity.getHeaders());
+            assertFalse(responseEntity.getHeaders().isEmpty());
+            assertNull(responseEntity.getBody());
+            countDownLatch.countDown();
+        };
+        Consumer<Throwable> onError = error -> Assertions.fail(error.getMessage());
+        restClient.headNonBlocking("/response", new ParameterizedTypeReference<Response>(){}, onSuccess, onError);
+        assertTrue(countDownLatch.await(SYNCHRONIZATION_TIMEOUT, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    void testHeadWithTestResponse() throws RestClientException {
+        ResponseEntity<TestResponse> responseEntity = restClient.head("/test-response", new ParameterizedTypeReference<TestResponse>() {});
+        assertNotNull(responseEntity.getHeaders());
+        assertFalse(responseEntity.getHeaders().isEmpty());
+        assertNull(responseEntity.getBody());
+    }
+
+    @Test
+    void testHeadWithObjectResponse() throws RestClientException {
+        ResponseEntity<ObjectResponse<TestResponse>> responseEntity = restClient.head("/object-response", new ParameterizedTypeReference<ObjectResponse<TestResponse>>() {});
+        assertNotNull(responseEntity.getHeaders());
+        assertFalse(responseEntity.getHeaders().isEmpty());
+        assertNull(responseEntity.getBody());
+    }
+
+    @Test
+    void testHeadWithObjectResponseObject() throws RestClientException {
+        ObjectResponse<TestResponse> response = restClient.headObject("/object-response", TestResponse.class);
+        assertEquals("OK", response.getStatus());
+        assertNull(response.getResponseObject());
+    }
+
+    @Test
+    void testHeadWithFullUrl() throws RestClientException {
+        RestClientConfiguration config = prepareConfiguration();
+        restClient = new DefaultRestClient(config);
+        Response response = restClient.headObject("https://localhost:" + port + "/api/test/response");
+        assertNotNull(response);
+        assertEquals("OK", response.getStatus());
+    }
+
+    @Test
     void testPatchWithFullUrl() throws RestClientException {
         RestClientConfiguration config = prepareConfiguration();
         restClient = new DefaultRestClient(config);

--- a/rest-model-base/src/main/java/io/getlime/core/rest/model/base/response/ObjectResponse.java
+++ b/rest-model-base/src/main/java/io/getlime/core/rest/model/base/response/ObjectResponse.java
@@ -19,7 +19,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 
 /**
- * Generic response with status and object object of a custom class.
+ * Generic response with status and object of a custom class.
  *
  * @author Petr Dvorak, petr@wultra.com
  *


### PR DESCRIPTION
All current GET endpoints on the test controller support also HEAD requests.
