### PR TITLE
Fix #223: Improve User-Agent parsing and add tests

### DIFF
--- a/audit-base/pom.xml
+++ b/audit-base/pom.xml
@@ -59,8 +59,8 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.2.2</version>
             </plugin>
         </plugins>
     </build>

--- a/http-common/pom.xml
+++ b/http-common/pom.xml
@@ -29,6 +29,11 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/http-common/pom.xml
+++ b/http-common/pom.xml
@@ -36,4 +36,13 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/http-common/src/main/java/com/wultra/core/http/common/headers/UserAgent.java
+++ b/http-common/src/main/java/com/wultra/core/http/common/headers/UserAgent.java
@@ -49,7 +49,7 @@ public final class UserAgent {
     private static final Pattern patternPrefix = Pattern.compile("^PowerAuthNetworking/(?<networkVersion>[0-9]+\\.[0-9]+\\.[0-9]+).*");
     private static final Pattern patternV1 = Pattern.compile("^PowerAuthNetworking/(?<networkVersion>[0-9]+\\.[0-9]+\\.[0-9]+) " +
             "\\((?<language>[a-zA-Z]{2}); (?<connection>[a-zA-Z0-9]+)\\) " +
-            "(?<product>[a-zA-Z0-9-_.]+)/(?<version>[0-9.]+) .*" +
+            "(?<product>[a-zA-Z0-9-_.]+)/(?<version>[0-9.]+(-[^ ]*)?) .*" +
             "\\((?<platform>[^;]+); (?<os>[^/]+)/(?<osVersion>[^;]+); (?<model>[^)]+)\\)$");
 
     /**

--- a/http-common/src/main/java/com/wultra/core/http/common/headers/UserAgent.java
+++ b/http-common/src/main/java/com/wultra/core/http/common/headers/UserAgent.java
@@ -26,6 +26,7 @@ import java.util.regex.Pattern;
  * Utility class for processing our standard user agent strings.
  *
  * @author Petr Dvorak, petr@wultra.com
+ * @author Lubos Racansky, lubos.racansky@wultra.com
  */
 @Slf4j
 public final class UserAgent {
@@ -44,10 +45,11 @@ public final class UserAgent {
     }
 
     private UserAgent() {
+        throw new IllegalStateException("Should not be instantiated");
     }
 
-    private static final Pattern patternPrefix = Pattern.compile("(^PowerAuthNetworking|.*PowerAuth2)/(?<networkVersion>[0-9]+\\.[0-9]+\\.[0-9]+).*");
-    private static final Pattern patternV1 = Pattern.compile("(^PowerAuthNetworking|.*PowerAuth2)/(?<networkVersion>[0-9]+\\.[0-9]+\\.[0-9]+) " +
+    private static final Pattern PATTERN_PREFIX = Pattern.compile("(^PowerAuthNetworking|.*PowerAuth2)/(?<networkVersion>[0-9]+\\.[0-9]+\\.[0-9]+).*");
+    private static final Pattern PATTERN_V1 = Pattern.compile("(^PowerAuthNetworking|.*PowerAuth2)/(?<networkVersion>[0-9]+\\.[0-9]+\\.[0-9]+) " +
             "(\\((?<language>[a-zA-Z]{2}); (?<connection>[a-zA-Z0-9]+)\\) )?" +
             "((?<product>[a-zA-Z0-9-_.]+)/(?<version>[0-9.]+(-[^ ]*)?) )?" +
             "(\\(((?<platform>[^;]+); )?(?<os>[^/ ]+)[/ ](?<osVersion>[^;,]+)[;,] (?<model>[^)]+)\\))?.*");
@@ -61,7 +63,7 @@ public final class UserAgent {
     public static Optional<Device> parse(String userAgent) {
         // Identify if the user agent is ours and in what version
         logger.debug("Parsing user agent value: {}", userAgent);
-        final Matcher matcherPrefix = patternPrefix.matcher(userAgent);
+        final Matcher matcherPrefix = PATTERN_PREFIX.matcher(userAgent);
         if (!matcherPrefix.matches()) {
             return Optional.empty();
         }
@@ -83,7 +85,7 @@ public final class UserAgent {
      * @return Parsed device info, or empty if the user agent header cannot be parsed.
      */
     private static Optional<Device> parseUserAgentV1(String userAgent) {
-        final Matcher matcher = patternV1.matcher(userAgent);
+        final Matcher matcher = PATTERN_V1.matcher(userAgent);
         if (matcher.matches()) {
             final Device device = new Device();
             device.setNetworkVersion(matcher.group("networkVersion"));

--- a/http-common/src/main/java/com/wultra/core/http/common/headers/UserAgent.java
+++ b/http-common/src/main/java/com/wultra/core/http/common/headers/UserAgent.java
@@ -48,8 +48,8 @@ public final class UserAgent {
         throw new IllegalStateException("Should not be instantiated");
     }
 
-    private static final Pattern PATTERN_PREFIX = Pattern.compile("(^PowerAuthNetworking|.*PowerAuth2)/(?<networkVersion>\\d+\\.\\d+\\.\\d+).*");
-    private static final Pattern PATTERN_V1 = Pattern.compile("(^PowerAuthNetworking|.*PowerAuth2)/(?<networkVersion>\\d+\\.\\d+\\.\\d+) " +
+    private static final Pattern PATTERN_PREFIX = Pattern.compile("((^PowerAuthNetworking)|.*PowerAuth2)/(?<networkVersion>\\d+\\.\\d+\\.\\d+).*");
+    private static final Pattern PATTERN_V1 = Pattern.compile("((^PowerAuthNetworking)|.*PowerAuth2)/(?<networkVersion>\\d+\\.\\d+\\.\\d+) " +
             "(\\((?<language>[a-zA-Z]{2}); (?<connection>[a-zA-Z0-9]+)\\) )?" +
             "((?<product>[a-zA-Z0-9-_.]+)/(?<version>[0-9.]+(-[^ ]*)?) )?" +
             "(\\(((?<platform>[^;]+); )?(?<os>[^/ ]+)[/ ](?<osVersion>[^;,]+)[;,] (?<model>[^)]+)\\))?.*");

--- a/http-common/src/main/java/com/wultra/core/http/common/headers/UserAgent.java
+++ b/http-common/src/main/java/com/wultra/core/http/common/headers/UserAgent.java
@@ -48,9 +48,9 @@ public final class UserAgent {
 
     private static final Pattern patternPrefix = Pattern.compile("(^PowerAuthNetworking|.*PowerAuth2)/(?<networkVersion>[0-9]+\\.[0-9]+\\.[0-9]+).*");
     private static final Pattern patternV1 = Pattern.compile("(^PowerAuthNetworking|.*PowerAuth2)/(?<networkVersion>[0-9]+\\.[0-9]+\\.[0-9]+) " +
-            "\\((?<language>[a-zA-Z]{2}); (?<connection>[a-zA-Z0-9]+)\\) " +
-            "(?<product>[a-zA-Z0-9-_.]+)/(?<version>[0-9.]+(-[^ ]*)?) .*" +
-            "\\((?<platform>[^;]+); (?<os>[^/]+)/(?<osVersion>[^;]+); (?<model>[^)]+)\\)$");
+            "(\\((?<language>[a-zA-Z]{2}); (?<connection>[a-zA-Z0-9]+)\\) )?" +
+            "((?<product>[a-zA-Z0-9-_.]+)/(?<version>[0-9.]+(-[^ ]*)?) )?" +
+            "(\\((?<platform>[^;]+); (?<os>[^/]+)/(?<osVersion>[^;]+); (?<model>[^)]+)\\))?.*");
 
     /**
      * Parse client user from the HTTP header value.

--- a/http-common/src/main/java/com/wultra/core/http/common/headers/UserAgent.java
+++ b/http-common/src/main/java/com/wultra/core/http/common/headers/UserAgent.java
@@ -46,8 +46,8 @@ public final class UserAgent {
     private UserAgent() {
     }
 
-    private static final Pattern patternPrefix = Pattern.compile("^PowerAuthNetworking/(?<networkVersion>[0-9]+\\.[0-9]+\\.[0-9]+).*");
-    private static final Pattern patternV1 = Pattern.compile("^PowerAuthNetworking/(?<networkVersion>[0-9]+\\.[0-9]+\\.[0-9]+) " +
+    private static final Pattern patternPrefix = Pattern.compile("(^PowerAuthNetworking|.*PowerAuth2)/(?<networkVersion>[0-9]+\\.[0-9]+\\.[0-9]+).*");
+    private static final Pattern patternV1 = Pattern.compile("(^PowerAuthNetworking|.*PowerAuth2)/(?<networkVersion>[0-9]+\\.[0-9]+\\.[0-9]+) " +
             "\\((?<language>[a-zA-Z]{2}); (?<connection>[a-zA-Z0-9]+)\\) " +
             "(?<product>[a-zA-Z0-9-_.]+)/(?<version>[0-9.]+(-[^ ]*)?) .*" +
             "\\((?<platform>[^;]+); (?<os>[^/]+)/(?<osVersion>[^;]+); (?<model>[^)]+)\\)$");

--- a/http-common/src/main/java/com/wultra/core/http/common/headers/UserAgent.java
+++ b/http-common/src/main/java/com/wultra/core/http/common/headers/UserAgent.java
@@ -50,7 +50,7 @@ public final class UserAgent {
     private static final Pattern patternV1 = Pattern.compile("(^PowerAuthNetworking|.*PowerAuth2)/(?<networkVersion>[0-9]+\\.[0-9]+\\.[0-9]+) " +
             "(\\((?<language>[a-zA-Z]{2}); (?<connection>[a-zA-Z0-9]+)\\) )?" +
             "((?<product>[a-zA-Z0-9-_.]+)/(?<version>[0-9.]+(-[^ ]*)?) )?" +
-            "(\\((?<platform>[^;]+); (?<os>[^/]+)/(?<osVersion>[^;]+); (?<model>[^)]+)\\))?.*");
+            "(\\(((?<platform>[^;]+); )?(?<os>[^/ ]+)[/ ](?<osVersion>[^;,]+)[;,] (?<model>[^)]+)\\))?.*");
 
     /**
      * Parse client user from the HTTP header value.

--- a/http-common/src/main/java/com/wultra/core/http/common/headers/UserAgent.java
+++ b/http-common/src/main/java/com/wultra/core/http/common/headers/UserAgent.java
@@ -48,8 +48,8 @@ public final class UserAgent {
         throw new IllegalStateException("Should not be instantiated");
     }
 
-    private static final Pattern PATTERN_PREFIX = Pattern.compile("(^PowerAuthNetworking|.*PowerAuth2)/(?<networkVersion>[0-9]+\\.[0-9]+\\.[0-9]+).*");
-    private static final Pattern PATTERN_V1 = Pattern.compile("(^PowerAuthNetworking|.*PowerAuth2)/(?<networkVersion>[0-9]+\\.[0-9]+\\.[0-9]+) " +
+    private static final Pattern PATTERN_PREFIX = Pattern.compile("(^PowerAuthNetworking|.*PowerAuth2)/(?<networkVersion>\\d+\\.\\d+\\.\\d+).*");
+    private static final Pattern PATTERN_V1 = Pattern.compile("(^PowerAuthNetworking|.*PowerAuth2)/(?<networkVersion>\\d+\\.\\d+\\.\\d+) " +
             "(\\((?<language>[a-zA-Z]{2}); (?<connection>[a-zA-Z0-9]+)\\) )?" +
             "((?<product>[a-zA-Z0-9-_.]+)/(?<version>[0-9.]+(-[^ ]*)?) )?" +
             "(\\(((?<platform>[^;]+); )?(?<os>[^/ ]+)[/ ](?<osVersion>[^;,]+)[;,] (?<model>[^)]+)\\))?.*");

--- a/http-common/src/main/java/com/wultra/core/http/common/headers/UserAgent.java
+++ b/http-common/src/main/java/com/wultra/core/http/common/headers/UserAgent.java
@@ -44,15 +44,17 @@ public final class UserAgent {
         private String model;
     }
 
+    private static final String PREFIX = "((^PowerAuthNetworking)|.*PowerAuth2)/(?<networkVersion>\\d+\\.\\d+\\.\\d+)";
+    private static final Pattern PATTERN_PREFIX = Pattern.compile(PREFIX + ".*");
+
+    private static final String LANGUAGE_AND_CONNECTION = "(\\((?<language>[a-zA-Z]{2}); (?<connection>[a-zA-Z0-9]+)\\) )?";
+    private static final String PRODUCT_AND_VERSION = "((?<product>[a-zA-Z0-9-_.]+)/(?<version>[0-9.]+(-[^ ]*)?) )?";
+    private static final String PLATFORM_OS_VERSION_MODEL = "(\\(((?<platform>[^;]+); )?(?<os>[^/ ]+)[/ ](?<osVersion>[^;,]+)[;,] (?<model>[^)]+)\\))?";
+    private static final Pattern PATTERN_V1 = Pattern.compile(PREFIX + " " + LANGUAGE_AND_CONNECTION + PRODUCT_AND_VERSION + PLATFORM_OS_VERSION_MODEL + ".*");
+
     private UserAgent() {
         throw new IllegalStateException("Should not be instantiated");
     }
-
-    private static final Pattern PATTERN_PREFIX = Pattern.compile("((^PowerAuthNetworking)|.*PowerAuth2)/(?<networkVersion>\\d+\\.\\d+\\.\\d+).*");
-    private static final Pattern PATTERN_V1 = Pattern.compile("((^PowerAuthNetworking)|.*PowerAuth2)/(?<networkVersion>\\d+\\.\\d+\\.\\d+) " +
-            "(\\((?<language>[a-zA-Z]{2}); (?<connection>[a-zA-Z0-9]+)\\) )?" +
-            "((?<product>[a-zA-Z0-9-_.]+)/(?<version>[0-9.]+(-[^ ]*)?) )?" +
-            "(\\(((?<platform>[^;]+); )?(?<os>[^/ ]+)[/ ](?<osVersion>[^;,]+)[;,] (?<model>[^)]+)\\))?.*");
 
     /**
      * Parse client user from the HTTP header value.

--- a/http-common/src/test/java/com/wultra/core/http/common/headers/UserAgentTest.java
+++ b/http-common/src/test/java/com/wultra/core/http/common/headers/UserAgentTest.java
@@ -21,13 +21,11 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 
-import java.util.List;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Test for the user agent parser.
+ * Test for {@link UserAgent}.
  *
  * @author Petr Dvorak, petr@wultra.com
  */
@@ -100,7 +98,6 @@ class UserAgentTest {
             final UserAgent.Device expectedDevice = expectedDevices[i];
             assertEquals(expectedDevice, device);
         }
-        //printCurrentDevices(devices);
     }
 
     private static UserAgent.Device[] readDevices() {
@@ -112,13 +109,4 @@ class UserAgentTest {
         }
     }
 
-    private static void printCurrentDevices(List<UserAgent.Device> devices) {
-        try {
-            final ObjectMapper om = new ObjectMapper();
-            final String s = om.writeValueAsString(devices);
-            System.out.println(s);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
-    }
 }

--- a/http-common/src/test/java/com/wultra/core/http/common/headers/UserAgentTest.java
+++ b/http-common/src/test/java/com/wultra/core/http/common/headers/UserAgentTest.java
@@ -32,6 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Test for {@link UserAgent}.
  *
  * @author Petr Dvorak, petr@wultra.com
+ * @author Lubos Racansky, lubos.racansky@wultra.com
  */
 class UserAgentTest {
 

--- a/http-common/src/test/java/com/wultra/core/http/common/headers/UserAgentTest.java
+++ b/http-common/src/test/java/com/wultra/core/http/common/headers/UserAgentTest.java
@@ -17,7 +17,11 @@ package com.wultra.core.http.common.headers;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
 
 import java.util.Optional;
 
@@ -31,82 +35,87 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class UserAgentTest {
 
-    private static final String[] USER_AGENTS = new String[] {
-            "PowerAuthNetworking/1.1.7 (en; cellular) com.wultra.app.Mobile-Token.wultra_test/2.0.0 (Apple; iOS/16.6.1; iphone12,3)",
-            "PowerAuthNetworking/1.2.1 (uk; wifi) com.wultra.android.mtoken.gdnexttest/1.0.0-gdnexttest (samsung; Android/13; SM-A047F)",
-            "PowerAuthNetworking/1.1.7 (en; unknown) com.wultra.app.MobileToken.wtest/2.0.0 (Apple; iOS/16.6.1; iphone10,6)",
-            "PowerAuthNetworking/1.1.7 (en; wifi) com.wultra.app.MobileToken.wtest/2.0.0 (Apple; iOS/16.7.1; iphone10,6)",
-            // MainBundle/Version PowerAuth2/Version (iOS Version, deviceString)
-            "PowerAuth2TestsHostApp-ios/1.0 PowerAuth2/1.7.8 (iOS 17.0, simulator)",
-            // PowerAuth2/Version (Android Version, Build.MANUFACTURER Build.MODEL)
-            "PowerAuth2/1.7.8 (Android 13, Google Pixel 4)",
-            "MobileToken/1.2.0 PowerAuth2/1.7.8 (iOS 15.7.9, iPhone9,3)"
-    };
-
-    private static final String DEVICES = """
-            [
-                {
-                    "networkVersion": "1.1.7",
-                    "language": "en",
-                    "connection": "cellular",
-                    "product": "com.wultra.app.Mobile-Token.wultra_test",
-                    "version": "2.0.0",
-                    "platform": "Apple",
-                    "os": "iOS",
-                    "osVersion": "16.6.1",
-                    "model": "iphone12,3"
-                },
-                {
-                    "networkVersion": "1.2.1",
-                    "language": "uk",
-                    "connection": "wifi",
-                    "product": "com.wultra.android.mtoken.gdnexttest",
-                    "version": "1.0.0-gdnexttest",
-                    "platform": "samsung",
-                    "os": "Android",
-                    "osVersion": "13",
-                    "model": "SM-A047F"
-                },
-                {
-                    "networkVersion": "1.1.7",
-                    "language": "en",
-                    "connection": "unknown",
-                    "product": "com.wultra.app.MobileToken.wtest",
-                    "version": "2.0.0",
-                    "platform": "Apple",
-                    "os": "iOS",
-                    "osVersion": "16.6.1",
-                    "model": "iphone10,6"
-                },
-                {
-                    "networkVersion": "1.1.7",
-                    "language": "en",
-                    "connection": "wifi",
-                    "product": "com.wultra.app.MobileToken.wtest",
-                    "version": "2.0.0",
-                    "platform": "Apple",
-                    "os": "iOS",
-                    "osVersion": "16.7.1",
-                    "model": "iphone10,6"
-                }
-            ]
-            """;
-
-    @Test
-    void testParse() throws Exception {
-        final UserAgent.Device[] expectedDevices = readDevices();
-        for (int i = 0; i < USER_AGENTS.length; i++) {
-            final Optional<UserAgent.Device> deviceOptional = UserAgent.parse(USER_AGENTS[i]);
-            assertTrue(deviceOptional.isPresent());
-
-            final UserAgent.Device expectedDevice = expectedDevices[i];
-            assertEquals(expectedDevice, deviceOptional.get());
-        }
+    @ParameterizedTest
+    @MethodSource("provideUserAgents")
+    void testParse(final String userAgent, final UserAgent.Device expectedDevice) {
+        final Optional<UserAgent.Device> deviceOptional = UserAgent.parse(userAgent);
+        assertTrue(deviceOptional.isPresent());
+        assertEquals(expectedDevice, deviceOptional.get());
     }
 
-    private static UserAgent.Device[] readDevices() throws JsonProcessingException {
-        final ObjectMapper om = new ObjectMapper();
-        return om.readValue(UserAgentTest.DEVICES, UserAgent.Device[].class);
+    private static Stream<Arguments> provideUserAgents() throws JsonProcessingException {
+        return Stream.of(
+                Arguments.of("PowerAuthNetworking/1.1.7 (en; cellular) com.wultra.app.Mobile-Token.wultra_test/2.0.0 (Apple; iOS/16.6.1; iphone12,3)", readDevice("""
+                        {
+                            "networkVersion": "1.1.7",
+                            "language": "en",
+                            "connection": "cellular",
+                            "product": "com.wultra.app.Mobile-Token.wultra_test",
+                            "version": "2.0.0",
+                            "platform": "Apple",
+                            "os": "iOS",
+                            "osVersion": "16.6.1",
+                            "model": "iphone12,3"
+                        }
+                        """)),
+                Arguments.of("PowerAuthNetworking/1.2.1 (uk; wifi) com.wultra.android.mtoken.gdnexttest/1.0.0-gdnexttest (samsung; Android/13; SM-A047F)", readDevice("""
+                        {
+                            "networkVersion": "1.2.1",
+                            "language": "uk",
+                            "connection": "wifi",
+                            "product": "com.wultra.android.mtoken.gdnexttest",
+                            "version": "1.0.0-gdnexttest",
+                            "platform": "samsung",
+                            "os": "Android",
+                            "osVersion": "13",
+                            "model": "SM-A047F"
+                        }
+                        """)),
+                Arguments.of("PowerAuthNetworking/1.1.7 (en; unknown) com.wultra.app.MobileToken.wtest/2.0.0 (Apple; iOS/16.6.1; iphone10,6)", readDevice("""
+                        {
+                            "networkVersion": "1.1.7",
+                            "language": "en",
+                            "connection": "unknown",
+                            "product": "com.wultra.app.MobileToken.wtest",
+                            "version": "2.0.0",
+                            "platform": "Apple",
+                            "os": "iOS",
+                            "osVersion": "16.6.1",
+                            "model": "iphone10,6"
+                        }
+                        """)),
+                Arguments.of("PowerAuthNetworking/1.1.7 (en; wifi) com.wultra.app.MobileToken.wtest/2.0.0 (Apple; iOS/16.7.1; iphone10,6)", readDevice("""
+                        {
+                            "networkVersion": "1.1.7",
+                            "language": "en",
+                            "connection": "wifi",
+                            "product": "com.wultra.app.MobileToken.wtest",
+                            "version": "2.0.0",
+                            "platform": "Apple",
+                            "os": "iOS",
+                            "osVersion": "16.7.1",
+                            "model": "iphone10,6"
+                        }
+                        """)),
+                // MainBundle/Version PowerAuth2/Version (iOS Version, deviceString)
+                // TODO Lubos
+                Arguments.of("PowerAuth2TestsHostApp-ios/1.0 PowerAuth2/1.7.8 (iOS 17.0, simulator)", readDevice("""
+                        {}
+                        """)),
+                // PowerAuth2/Version (Android Version, Build.MANUFACTURER Build.MODEL)
+                // TODO Lubos
+                Arguments.of("PowerAuth2/1.7.8 (Android 13, Google Pixel 4)", readDevice("""
+                        {}
+                        """)),
+                // TODO Lubos
+                Arguments.of("MobileToken/1.2.0 PowerAuth2/1.7.8 (iOS 15.7.9, iPhone9,3)", readDevice("""
+                        {}
+                        """))
+        );
+    }
+
+    private static UserAgent.Device readDevice(final String json) throws JsonProcessingException {
+        return new ObjectMapper().readValue(json, UserAgent.Device.class);
     }
 
 }

--- a/http-common/src/test/java/com/wultra/core/http/common/headers/UserAgentTest.java
+++ b/http-common/src/test/java/com/wultra/core/http/common/headers/UserAgentTest.java
@@ -98,18 +98,21 @@ class UserAgentTest {
                         }
                         """)),
                 // MainBundle/Version PowerAuth2/Version (iOS Version, deviceString)
-                // TODO Lubos
                 Arguments.of("PowerAuth2TestsHostApp-ios/1.0 PowerAuth2/1.7.8 (iOS 17.0, simulator)", readDevice("""
-                        {}
+                        {
+                            "networkVersion": "1.7.8"
+                        }
                         """)),
                 // PowerAuth2/Version (Android Version, Build.MANUFACTURER Build.MODEL)
-                // TODO Lubos
                 Arguments.of("PowerAuth2/1.7.8 (Android 13, Google Pixel 4)", readDevice("""
-                        {}
+                        {
+                            "networkVersion": "1.7.8"
+                        }
                         """)),
-                // TODO Lubos
                 Arguments.of("MobileToken/1.2.0 PowerAuth2/1.7.8 (iOS 15.7.9, iPhone9,3)", readDevice("""
-                        {}
+                        {
+                            "networkVersion": "1.7.8"
+                        }
                         """))
         );
     }

--- a/http-common/src/test/java/com/wultra/core/http/common/headers/UserAgentTest.java
+++ b/http-common/src/test/java/com/wultra/core/http/common/headers/UserAgentTest.java
@@ -35,7 +35,12 @@ class UserAgentTest {
             "PowerAuthNetworking/1.1.7 (en; cellular) com.wultra.app.Mobile-Token.wultra_test/2.0.0 (Apple; iOS/16.6.1; iphone12,3)",
             "PowerAuthNetworking/1.2.1 (uk; wifi) com.wultra.android.mtoken.gdnexttest/1.0.0-gdnexttest (samsung; Android/13; SM-A047F)",
             "PowerAuthNetworking/1.1.7 (en; unknown) com.wultra.app.MobileToken.wtest/2.0.0 (Apple; iOS/16.6.1; iphone10,6)",
-            "PowerAuthNetworking/1.1.7 (en; wifi) com.wultra.app.MobileToken.wtest/2.0.0 (Apple; iOS/16.7.1; iphone10,6)"
+            "PowerAuthNetworking/1.1.7 (en; wifi) com.wultra.app.MobileToken.wtest/2.0.0 (Apple; iOS/16.7.1; iphone10,6)",
+            // MainBundle/Version PowerAuth2/Version (iOS Version, deviceString)
+            "PowerAuth2TestsHostApp-ios/1.0 PowerAuth2/1.7.8 (iOS 17.0, simulator)",
+            // PowerAuth2/Version (Android Version, Build.MANUFACTURER Build.MODEL)
+            "PowerAuth2/1.7.8 (Android 13, Google Pixel 4)",
+            "MobileToken/1.2.0 PowerAuth2/1.7.8 (iOS 15.7.9, iPhone9,3)"
     };
 
     private static final String DEVICES = """
@@ -88,25 +93,20 @@ class UserAgentTest {
             """;
 
     @Test
-    void parse() {
+    void testParse() throws Exception {
         final UserAgent.Device[] expectedDevices = readDevices();
         for (int i = 0; i < USER_AGENTS.length; i++) {
             final Optional<UserAgent.Device> deviceOptional = UserAgent.parse(USER_AGENTS[i]);
             assertTrue(deviceOptional.isPresent());
 
-        final UserAgent.Device device = deviceOptional.get();
             final UserAgent.Device expectedDevice = expectedDevices[i];
-            assertEquals(expectedDevice, device);
+            assertEquals(expectedDevice, deviceOptional.get());
         }
     }
 
-    private static UserAgent.Device[] readDevices() {
-        try {
-            final ObjectMapper om = new ObjectMapper();
-            return om.readValue(UserAgentTest.DEVICES, UserAgent.Device[].class);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
+    private static UserAgent.Device[] readDevices() throws JsonProcessingException {
+        final ObjectMapper om = new ObjectMapper();
+        return om.readValue(UserAgentTest.DEVICES, UserAgent.Device[].class);
     }
 
 }

--- a/http-common/src/test/java/com/wultra/core/http/common/headers/UserAgentTest.java
+++ b/http-common/src/test/java/com/wultra/core/http/common/headers/UserAgentTest.java
@@ -39,7 +39,7 @@ class UserAgentTest {
     @MethodSource("provideUserAgents")
     void testParse(final String userAgent, final UserAgent.Device expectedDevice) {
         final Optional<UserAgent.Device> deviceOptional = UserAgent.parse(userAgent);
-        assertTrue(deviceOptional.isPresent());
+        assertTrue(deviceOptional.isPresent(), "Unable to parse user-agent: " + userAgent);
         assertEquals(expectedDevice, deviceOptional.get());
     }
 

--- a/http-common/src/test/java/com/wultra/core/http/common/headers/UserAgentTest.java
+++ b/http-common/src/test/java/com/wultra/core/http/common/headers/UserAgentTest.java
@@ -100,18 +100,27 @@ class UserAgentTest {
                 // MainBundle/Version PowerAuth2/Version (iOS Version, deviceString)
                 Arguments.of("PowerAuth2TestsHostApp-ios/1.0 PowerAuth2/1.7.8 (iOS 17.0, simulator)", readDevice("""
                         {
-                            "networkVersion": "1.7.8"
+                            "networkVersion": "1.7.8",
+                            "os": "iOS",
+                            "osVersion": "17.0",
+                            "model": "simulator"
                         }
                         """)),
                 // PowerAuth2/Version (Android Version, Build.MANUFACTURER Build.MODEL)
                 Arguments.of("PowerAuth2/1.7.8 (Android 13, Google Pixel 4)", readDevice("""
                         {
-                            "networkVersion": "1.7.8"
+                            "networkVersion": "1.7.8",
+                            "os": "Android",
+                            "osVersion": "13",
+                            "model": "Google Pixel 4"
                         }
                         """)),
                 Arguments.of("MobileToken/1.2.0 PowerAuth2/1.7.8 (iOS 15.7.9, iPhone9,3)", readDevice("""
                         {
-                            "networkVersion": "1.7.8"
+                            "networkVersion": "1.7.8",
+                            "os": "iOS",
+                            "osVersion": "15.7.9",
+                            "model": "iPhone9,3"
                         }
                         """))
         );

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>17</maven.compiler.source>
 		<maven.compiler.target>17</maven.compiler.target>
+		<maven-surefire-plugin.version>3.2.2</maven-surefire-plugin.version>
 
 		<!-- Dependencies -->
 		<spring-boot.version>3.1.6</spring-boot.version>
@@ -96,6 +97,16 @@
 	</dependencies>
 
 	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-surefire-plugin</artifactId>
+					<version>${maven-surefire-plugin.version}</version>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/rest-client-base/pom.xml
+++ b/rest-client-base/pom.xml
@@ -66,8 +66,8 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.2.2</version>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Please check if the tests should cover any other User-Agent string format provided by our mobile token SDK on iOS and Android.